### PR TITLE
v1.0.2 - Correct Codesandbox links

### DIFF
--- a/apps/rhf-mui-demo/src/constants/source-code-links.ts
+++ b/apps/rhf-mui-demo/src/constants/source-code-links.ts
@@ -1,7 +1,8 @@
 import { ENV_VARS } from './env-vars';
 import { Page } from '@/types';
 
-const sandboxRoute = ENV_VARS.SANDBOX_URL;
+const sandboxPath = ENV_VARS.SANDBOX_URL;
+const sandboxRoute = `${sandboxPath}?file=/src/forms` 
 const sandboxPrefix = 'CodeSandbox - ';
 const commonRoute = 'https://github.com/nishkohli96/rhf-mui-components/tree/main/apps/rhf-mui-demo/src/forms';
 

--- a/apps/rhf-mui-docs/docs/customization.mdx
+++ b/apps/rhf-mui-docs/docs/customization.mdx
@@ -48,8 +48,8 @@ Override the default `FormLabel` and `FormHelperText` values by providing
 the desired values in `defaultFormLabelSx` and `defaultFormHelperTextSx` props
 which accepts all valid values in the [`sx` prop](https://mui.com/material-ui/customization/how-to-customize/#the-sx-prop).
 
-You can also specify a different `dateAdapter` for date and time pickers. 
-For a full list of available date adapters, see the 
+Additionally you also need to specify a `dateAdapter` for date and time pickers using 
+`ConfigProvider` component. For a full list of available date adapters, see the 
 [MUI date library options](https://mui.com/x/react-date-pickers/base-concepts/#date-library).
 Please do install the npm package of the corresponding date library.
 

--- a/apps/rhf-mui-docs/src/page-components/customization/index.tsx
+++ b/apps/rhf-mui-docs/src/page-components/customization/index.tsx
@@ -6,8 +6,8 @@ export default function DefaultConfigValuesTable() {
   const row1 = '| defaultFormLabelSx | { marginBottom: "0.75rem" } |\n';
   const row2 = '| defaultFormControlLabelSx | {} |\n';
   const row3 = '| defaultFormHelperTextSx | { marginTop: "0.25rem", marginLeft: 0 } |\n';
-  const row4 = '| dateAdapter | AdapterDayjs |\n';
-  const content = header + row1 + row2 + row3 + row4;
+
+  const content = header + row1 + row2 + row3;
   return (
     <Markdown remarkPlugins={[remarkGfm]}>
       {content}


### PR DESCRIPTION
1. Correct link paths to open correct files on clicking any of the csb links in examples site
2. Remove `dateAdapter` from defaults table in `docs/customization` page. 