### PR TITLE
v1.0.3-docs - Update Website Layout

### DIFF
--- a/apps/rhf-mui-docs/docs/changelog.md
+++ b/apps/rhf-mui-docs/docs/changelog.md
@@ -13,7 +13,7 @@ description: Introduction and installation of @nish1896/rhf-mui-components packa
 
 - Fix `defaultFormHelperTextSx` bug in `ConfigProvider`.
 - Handle snake-case convention to render default form label text.
-- Added [Playground link](https://codesandbox.io/p/devbox/rhf-mui-components-examples-y8lj9l) on docs homepage.
+- Added [Examples](https://rhf-mui-components-examples.netlify.app/) and [Playground](https://codesandbox.io/p/devbox/rhf-mui-components-examples-y8lj9l) links on appbar in docs website.
 - Added ***downloads per month*** metric in README.
 - Use [tsc-alias](https://www.npmjs.com/package/tsc-alias) for alias imports.
 - Lint package using my own [eslint config](https://www.npmjs.com/package/@nish1896/eslint-config).

--- a/apps/rhf-mui-docs/docusaurus.config.ts
+++ b/apps/rhf-mui-docs/docusaurus.config.ts
@@ -34,11 +34,22 @@ const config: Config = {
       respectPrefersColorScheme: true
     },
     navbar: {
+      title: 'RHF-MUI Components',
       logo: {
-        alt: 'My Site Logo',
+        alt: 'Website Logo',
         src: 'img/logo.svg'
       },
       items: [
+        {
+          href: 'https://rhf-mui-components-examples.netlify.app/',
+          label: 'Examples',
+          position: 'right'
+        },
+        {
+          href: 'https://codesandbox.io/p/devbox/rhf-mui-components-examples-y8lj9l',
+          label: 'Playground',
+          position: 'right'
+        },
         {
           href: 'https://github.com/nishkohli96/rhf-mui-components',
           label: 'GitHub',

--- a/apps/rhf-mui-docs/src/constants/index.ts
+++ b/apps/rhf-mui-docs/src/constants/index.ts
@@ -1,5 +1,4 @@
 export { default as ExternalLinks } from './external-links';
-export { default as InternalLinks } from './internal-links';
 export { default as PropsDescription } from './props';
 
 

--- a/apps/rhf-mui-docs/src/constants/internal-links.ts
+++ b/apps/rhf-mui-docs/src/constants/internal-links.ts
@@ -1,6 +1,0 @@
-const InternalLinks = Object.freeze({
-  demo: 'https://rhf-mui-components-examples.netlify.app/',
-  playground: 'https://codesandbox.io/p/devbox/rhf-mui-components-examples-y8lj9l'
-});
-
-export default InternalLinks;

--- a/apps/rhf-mui-docs/src/pages/index.tsx
+++ b/apps/rhf-mui-docs/src/pages/index.tsx
@@ -6,10 +6,7 @@ import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
 import { ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
-import { useTheme } from '@mui/material/styles';
-import useMediaQuery from '@mui/material/useMediaQuery';
 import { HomePageButton } from '@site/src/components';
-import { InternalLinks } from '@site/src/constants';
 import theme from '@site/src/styles/theme';
 import styles from './index.module.css';
 
@@ -17,39 +14,16 @@ const IntroductionBtn = () => (
   <HomePageButton text="Get Started" href="/introduction" bgColor="#25C19F" />
 );
 
-const ExamplesBtn = () => (
-  <HomePageButton
-    text="View Examples"
-    href={InternalLinks.demo}
-    bgColor="#54C7EC"
-  />
-);
-
-const PlaygroundBtn = () => (
-  <HomePageButton
-    text="Playground"
-    href={InternalLinks.playground}
-    bgColor="#ff6b6b"
-  />
-);
-
 const HomepageButtons = () => {
-  const theme = useTheme();
-  const isLargeScreen = useMediaQuery(theme.breakpoints.up('md'));
-
   return (
     <Grid container justifyContent="center" sx={{ mt: '40px' }}>
       <Box
         sx={{
           display: 'flex',
-          flexDirection: isLargeScreen ? 'row' : 'column',
-          gap: isLargeScreen ? '30px' : '25px',
           alignItems: 'center'
         }}
       >
         <IntroductionBtn />
-        <ExamplesBtn />
-        <PlaygroundBtn />
       </Box>
     </Grid>
   );

--- a/packages/rhf-mui-components/package.json
+++ b/packages/rhf-mui-components/package.json
@@ -18,9 +18,9 @@
     "tsc-alias": "^1.8.10"
   },
 	"peerDependencies": {
-		"@mui/icons-material": ">=5",
+    "@mui/icons-material": ">=5",
     "@mui/material": ">=5",
-		"react-hook-form": ">=7"
+    "react-hook-form": ">=7"
 	},
   "exports": {
     "./config": "./config/index.js",

--- a/packages/rhf-mui-components/package.json
+++ b/packages/rhf-mui-components/package.json
@@ -17,7 +17,7 @@
     "rimraf": "^6.0.1",
     "tsc-alias": "^1.8.10"
   },
-	"peerDependencies": {
+  "peerDependencies": {
     "@mui/icons-material": ">=5",
     "@mui/material": ">=5",
     "react-hook-form": ">=7"


### PR DESCRIPTION
- Place examples and playground links in appbar for docs website instead of homepage as it was causing visual glitch of moving buttons from centre to inline for larger screen, on initial loading
- Add site title in appbar 