### PR TITLE
v3.0.1 - onBlur event in form fields

### DIFF
--- a/apps/rhf-mui-demo/package.json
+++ b/apps/rhf-mui-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-demo",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "private": true,
   "author": "Nishant Kohli",
   "scripts": {

--- a/apps/rhf-mui-demo/src/forms/checkbox-and-radiogroup-with-zod/index.tsx
+++ b/apps/rhf-mui-demo/src/forms/checkbox-and-radiogroup-with-zod/index.tsx
@@ -62,7 +62,6 @@ const CheckboxRadioZodForm = () => {
               valueKey="code"
               required
               errorMessage={errors?.countriesVisited?.message}
-              onBlur={e=> console.log('CheckboxGroup onBlur', e.target.value)} 
             />
           </Grid>
           <Grid size={{ xs: 12, md: 6 }}>

--- a/apps/rhf-mui-demo/src/forms/checkbox-and-radiogroup-with-zod/index.tsx
+++ b/apps/rhf-mui-demo/src/forms/checkbox-and-radiogroup-with-zod/index.tsx
@@ -62,6 +62,7 @@ const CheckboxRadioZodForm = () => {
               valueKey="code"
               required
               errorMessage={errors?.countriesVisited?.message}
+              onBlur={e=> console.log('CheckboxGroup onBlur', e.target.value)} 
             />
           </Grid>
           <Grid size={{ xs: 12, md: 6 }}>

--- a/apps/rhf-mui-docs/package.json
+++ b/apps/rhf-mui-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-docs",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/changelog/v3.md
+++ b/changelog/v3.md
@@ -4,7 +4,7 @@
 
 **Released - 2 July, 2025**
 
-- Handle `onBlur` for all fields except for `RHFFileUploader`
+- Handle `onBlur` for all fields except for `RHFFileUploader`, `RHFColorPicker`. The blur event for date and time pickers can be passed via `slotProps.textField`.
 
 ## [3.0.0](https://github.com/nishkohli96/rhf-mui-components/tree/v3.0.0)
 

--- a/changelog/v3.md
+++ b/changelog/v3.md
@@ -1,5 +1,11 @@
 # Changelog - v3
 
+## [3.0.1](https://github.com/nishkohli96/rhf-mui-components/tree/v3.0.1)
+
+**Released - 2 July, 2025**
+
+- Handle `onBlur` for all fields except for `RHFFileUploader`
+
 ## [3.0.0](https://github.com/nishkohli96/rhf-mui-components/tree/v3.0.0)
 
 **Released - 11 May, 2025**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-components-root",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A suite of 20+ reusable mui components for react-hook-form to minimize your time and effort in creating and styling forms",
   "author": "Nishant Kohli",
   "private": true,

--- a/packages/rhf-mui-components/package.json
+++ b/packages/rhf-mui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-components",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A suite of 20+ reusable Material UI components for React Hook Form to minimize your time and effort in creating and styling forms",
   "author": "Nishant Kohli",
   "homepage": "https://rhf-mui-components.netlify.app/",

--- a/packages/rhf-mui-components/src/misc/phone-input/index.tsx
+++ b/packages/rhf-mui-components/src/misc/phone-input/index.tsx
@@ -90,6 +90,7 @@ const RHFPhoneInput = <T extends FieldValues>({
   disabled,
   phoneInputProps,
   slotProps,
+  onBlur,
   ...rest
 }: RHFPhoneInputProps<T>) => {
   const { allLabelsAboveFields } = useContext(RHFMuiConfigContext);
@@ -268,6 +269,10 @@ const RHFPhoneInput = <T extends FieldValues>({
               inputRef={ref => {
                 field.ref(ref);
                 inputRef.current = ref;
+              }}
+              onBlur={blurEvent => {
+                field.onBlur();
+                onBlur?.(blurEvent);
               }}
               label={!isLabelAboveFormField
                 ? <FormLabelText label={fieldLabel} required={required} />

--- a/packages/rhf-mui-components/src/mui/autocomplete/index.tsx
+++ b/packages/rhf-mui-components/src/mui/autocomplete/index.tsx
@@ -104,6 +104,7 @@ const RHFAutocomplete = <T extends FieldValues>({
   textFieldProps,
   slotProps,
   ChipProps,
+  onBlur,
   ...otherAutoCompleteProps
 }: RHFAutocompleteProps<T>) => {
   validateArray('RHFAutocomplete', options, labelKey, valueKey);
@@ -131,7 +132,7 @@ const RHFAutocomplete = <T extends FieldValues>({
         name={fieldName}
         control={control}
         rules={registerOptions}
-        render={({ field: { value, onChange, ...otherFieldProps } }) => {
+        render={({ field: { value, onChange, onBlur: rhfOnBlur, ...otherFieldProps } }) => {
           /**
            * When considering for the case when options is an array of objects,
            * the values would be an array or a single "valueKey" from these options.
@@ -189,6 +190,10 @@ const RHFAutocomplete = <T extends FieldValues>({
                       : newValue;
                 onChange(fieldValue);
                 onValueChange?.(fieldValue, event, reason, details);
+              }}
+              onBlur={blurEvent => {
+                rhfOnBlur();
+                onBlur?.(blurEvent);
               }}
               limitTags={2}
               getLimitTagsText={value => `+${value} More`}

--- a/packages/rhf-mui-components/src/mui/checkbox-group/index.tsx
+++ b/packages/rhf-mui-components/src/mui/checkbox-group/index.tsx
@@ -52,6 +52,7 @@ export type RHFCheckboxGroupProps<T extends FieldValues> = {
   errorMessage?: ReactNode;
   hideErrorMessage?: boolean;
   formHelperTextProps?: FormHelperTextProps;
+  onBlur?: (event: React.FocusEvent<HTMLButtonElement, Element>) => void;
 };
 
 const RHFCheckboxGroup = <T extends FieldValues>({
@@ -72,7 +73,8 @@ const RHFCheckboxGroup = <T extends FieldValues>({
   helperText,
   errorMessage,
   hideErrorMessage,
-  formHelperTextProps
+  formHelperTextProps,
+  onBlur,
 }: RHFCheckboxGroupProps<T>) => {
   validateArray('RHFCheckboxGroup', options, labelKey, valueKey);
 
@@ -100,7 +102,7 @@ const RHFCheckboxGroup = <T extends FieldValues>({
         control={control}
         rules={registerOptions}
         render={({ field }) => {
-          const { value, onChange } = field;
+          const { value, onChange, onBlur: rhfOnBlur } = field;
           const handleChange = (
             event: ChangeEvent<HTMLInputElement>,
             checked: boolean
@@ -135,6 +137,10 @@ const RHFCheckboxGroup = <T extends FieldValues>({
                           (value as StringArr) ?? []
                         ).includes(opnValue)}
                         onChange={e => handleChange(e, e.target.checked)}
+                        onBlur={blurEvent => {
+                          rhfOnBlur();
+                          onBlur?.(blurEvent);
+                        }}
                       />
                     }
                     label={`${opnLabel}`}

--- a/packages/rhf-mui-components/src/mui/checkbox/index.tsx
+++ b/packages/rhf-mui-components/src/mui/checkbox/index.tsx
@@ -45,6 +45,7 @@ const RHFCheckbox = <T extends FieldValues>({
   errorMessage,
   hideErrorMessage,
   formHelperTextProps,
+  onBlur,
   ...rest
 }: RHFCheckboxProps<T>) => {
   const { defaultFormControlLabelSx } = useContext(RHFMuiConfigContext);
@@ -64,7 +65,7 @@ const RHFCheckbox = <T extends FieldValues>({
         control={control}
         rules={registerOptions}
         render={({ field }) => {
-          const { value, onChange, ...otherFieldParams } = field;
+          const { value, onChange, onBlur: rhfOnBlur, ...otherFieldParams } = field;
           return (
             <FormControlLabel
               control={
@@ -77,6 +78,10 @@ const RHFCheckbox = <T extends FieldValues>({
                     if(onValueChange) {
                       onValueChange(checked, event);
                     }
+                  }}
+                  onBlur={blurEvent => {
+                    rhfOnBlur();
+                    onBlur?.(blurEvent);
                   }}
                 />
               }

--- a/packages/rhf-mui-components/src/mui/country-select/index.tsx
+++ b/packages/rhf-mui-components/src/mui/country-select/index.tsx
@@ -106,6 +106,7 @@ const RHFCountrySelect = <T extends FieldValues>({
   displayFlagOnSelect,
   slotProps,
   ChipProps,
+  onBlur,
   ...otherAutoCompleteProps
 }: RHFCountrySelectProps<T>) => {
   const { allLabelsAboveFields } = useContext(RHFMuiConfigContext);
@@ -163,7 +164,7 @@ const RHFCountrySelect = <T extends FieldValues>({
         name={fieldName}
         control={control}
         rules={registerOptions}
-        render={({ field: { value, onChange, ...otherFieldProps } }) => {
+        render={({ field: { value, onChange, onBlur: rhfOnBlur, ...otherFieldProps } }) => {
           const selectedCountries = multiple
             ? (value ?? [])
               .map(val => countrySelectOptions.find(country => country[valueKey] === val))
@@ -185,6 +186,10 @@ const RHFCountrySelect = <T extends FieldValues>({
                 if (onValueChange) {
                   onValueChange(newValue, event, reason, details);
                 }
+              }}
+              onBlur={blurEvent => {
+                rhfOnBlur();
+                onBlur?.(blurEvent);
               }}
               autoHighlight
               blurOnSelect={!multiple}

--- a/packages/rhf-mui-components/src/mui/multi-autocomplete/index.tsx
+++ b/packages/rhf-mui-components/src/mui/multi-autocomplete/index.tsx
@@ -105,6 +105,7 @@ const RHFMultiAutocomplete = <T extends FieldValues>({
   textFieldProps,
   slotProps,
   ChipProps,
+  onBlur,
   ...otherAutoCompleteProps
 }: RHFMultiAutocompleteProps<T>) => {
   validateArray('RHFMultiAutocomplete', options, labelKey, valueKey);
@@ -188,7 +189,7 @@ const RHFMultiAutocomplete = <T extends FieldValues>({
         name={fieldName}
         control={control}
         rules={registerOptions}
-        render={({ field: { value, onChange, ...otherFieldProps } }) => {
+        render={({ field: { value, onChange, onBlur: rhfOnBlur, ...otherFieldProps } }) => {
           const selectedOptions = (value ?? [])
             .map(val =>
               options.find(opn =>
@@ -237,6 +238,10 @@ const RHFMultiAutocomplete = <T extends FieldValues>({
                     .filter(opn => opn !== valueOfClickedItem);
                   changeFieldState(fieldValue, valueOfClickedItem);
                 }
+              }}
+              onBlur={blurEvent => {
+                rhfOnBlur();
+                onBlur?.(blurEvent);
               }}
               limitTags={2}
               getLimitTagsText={value => `+${value} More`}

--- a/packages/rhf-mui-components/src/mui/native-select/index.tsx
+++ b/packages/rhf-mui-components/src/mui/native-select/index.tsx
@@ -64,6 +64,7 @@ const RHFNativeSelect = <T extends FieldValues>({
   hideErrorMessage,
   formHelperTextProps,
   sx,
+  onBlur,
   ...otherNativeSelectProps
 }: RHFNativeSelectProps<T>) => {
   validateArray('RHFNativeSelect', options, labelKey, valueKey);
@@ -85,7 +86,7 @@ const RHFNativeSelect = <T extends FieldValues>({
         name={fieldName}
         control={control}
         rules={registerOptions}
-        render={({ field: { onChange, value, ...rest } }) => (
+        render={({ field: { onChange, value, onBlur: rhfOnBlur, ...rest } }) => (
           <NativeSelect
             {...otherNativeSelectProps}
             {...rest}
@@ -99,6 +100,10 @@ const RHFNativeSelect = <T extends FieldValues>({
               if (onValueChange) {
                 onValueChange(event.target.value, event);
               }
+            }}
+            onBlur={blurEvent => {
+              rhfOnBlur();
+              onBlur?.(blurEvent);
             }}
             sx={{
               ...sx,

--- a/packages/rhf-mui-components/src/mui/number-input/index.tsx
+++ b/packages/rhf-mui-components/src/mui/number-input/index.tsx
@@ -50,6 +50,7 @@ const RHFNumberInput = <T extends FieldValues>({
   hideErrorMessage,
   formHelperTextProps,
   sx,
+  onBlur,
   ...rest
 }: RHFNumberInputProps<T>) => {
   const { allLabelsAboveFields } = useContext(RHFMuiConfigContext);
@@ -74,7 +75,7 @@ const RHFNumberInput = <T extends FieldValues>({
         control={control}
         rules={registerOptions}
         render={({ field }) => {
-          const { value, onChange, ...otherFieldParams } = field;
+          const { value, onChange, onBlur: rhfOnBlur, ...otherFieldParams } = field;
           return (
             <MuiTextField
               id={fieldName}
@@ -92,9 +93,11 @@ const RHFNumberInput = <T extends FieldValues>({
                 const fieldValue
                   = event.target.value === '' ? null : Number(event.target.value);
                 onChange(fieldValue);
-                if (onValueChange) {
-                  onValueChange(fieldValue, event);
-                }
+                onValueChange?.(fieldValue, event);
+              }}
+              onBlur={blurEvent => {
+                rhfOnBlur();
+                onBlur?.(blurEvent);
               }}
               error={isError}
               sx={{

--- a/packages/rhf-mui-components/src/mui/password-input/index.tsx
+++ b/packages/rhf-mui-components/src/mui/password-input/index.tsx
@@ -95,7 +95,7 @@ const RHFPasswordInput = <T extends FieldValues>({
         control={control}
         rules={registerOptions}
         render={({ field }) => {
-          const { value, onChange, onBlur:rhfOnBlur, ...otherFieldParams } = field;
+          const { value, onChange, onBlur: rhfOnBlur, ...otherFieldParams } = field;
           const endAdornment = (
             <InputAdornment position="end">
               <IconButton

--- a/packages/rhf-mui-components/src/mui/password-input/index.tsx
+++ b/packages/rhf-mui-components/src/mui/password-input/index.tsx
@@ -61,6 +61,7 @@ const RHFPasswordInput = <T extends FieldValues>({
   hideErrorMessage,
   formHelperTextProps,
   slotProps,
+  onBlur,
   ...rest
 }: RHFPasswordInputProps<T>) => {
   const { allLabelsAboveFields } = useContext(RHFMuiConfigContext);
@@ -94,7 +95,7 @@ const RHFPasswordInput = <T extends FieldValues>({
         control={control}
         rules={registerOptions}
         render={({ field }) => {
-          const { value, onChange, ...otherFieldParams } = field;
+          const { value, onChange, onBlur:rhfOnBlur, ...otherFieldParams } = field;
           const endAdornment = (
             <InputAdornment position="end">
               <IconButton
@@ -123,9 +124,11 @@ const RHFPasswordInput = <T extends FieldValues>({
               value={value ?? ''}
               onChange={event => {
                 onChange(event);
-                if (onValueChange) {
-                  onValueChange(event.target.value, event);
-                }
+                onValueChange?.(event.target.value, event);
+              }}
+              onBlur={blurEvent => {
+                rhfOnBlur();
+                onBlur?.(blurEvent);
               }}
               error={isError}
               {...(isAboveMuiV5

--- a/packages/rhf-mui-components/src/mui/radio-group/index.tsx
+++ b/packages/rhf-mui-components/src/mui/radio-group/index.tsx
@@ -74,6 +74,7 @@ const RHFRadioGroup = <T extends FieldValues>({
   errorMessage,
   hideErrorMessage,
   formHelperTextProps,
+  onBlur,
   ...rest
 }: RHFRadioGroupProps<T>) => {
   validateArray('RHFRadioGroup', options, labelKey, valueKey);
@@ -102,17 +103,21 @@ const RHFRadioGroup = <T extends FieldValues>({
         control={control}
         rules={registerOptions}
         render={({ field }) => {
-          const { onChange, ...otherFieldParams } = field;
+          const { onChange, onBlur: rhfOnBlur, value, ...otherFieldParams } = field;
           return (
             <MuiRadioGroup
               {...rest}
               {...otherFieldParams}
-              value={field.value ?? ''}
+              value={value ?? ''}
               onChange={(event, selectedValue) => {
                 onChange(event);
                 if(onValueChange) {
                   onValueChange(selectedValue, event);
                 }
+              }}
+              onBlur={blurEvent => {
+                rhfOnBlur();
+                onBlur?.(blurEvent);
               }}
               aria-disabled={disabled}
             >

--- a/packages/rhf-mui-components/src/mui/rating/index.tsx
+++ b/packages/rhf-mui-components/src/mui/rating/index.tsx
@@ -51,6 +51,7 @@ const RHFRating = <T extends FieldValues>({
   errorMessage,
   hideErrorMessage,
   formHelperTextProps,
+  onBlur,
   ...rest
 }: RHFRatingProps<T>) => {
   const fieldLabel = label ?? fieldNameToLabel(fieldName);
@@ -70,7 +71,7 @@ const RHFRating = <T extends FieldValues>({
         control={control}
         rules={registerOptions}
         render={({ field }) => {
-          const { value, onChange, ...otherFieldParams } = field;
+          const { value, onChange, onBlur: rhfOnBlur, ...otherFieldParams } = field;
           return (
             <MuiRating
               {...rest}
@@ -81,6 +82,10 @@ const RHFRating = <T extends FieldValues>({
                 if(onValueChange) {
                   onValueChange(newValue, event);
                 }
+              }}
+              onBlur={blurEvent => {
+                rhfOnBlur();
+                onBlur?.(blurEvent);
               }}
             />
           );

--- a/packages/rhf-mui-components/src/mui/select/index.tsx
+++ b/packages/rhf-mui-components/src/mui/select/index.tsx
@@ -72,6 +72,7 @@ const RHFSelect = <T extends FieldValues>({
   errorMessage,
   hideErrorMessage,
   formHelperTextProps,
+  onBlur,
   ...otherSelectProps
 }: RHFSelectProps<T>) => {
   validateArray('RHFSelect', options, labelKey, valueKey);
@@ -111,7 +112,7 @@ const RHFSelect = <T extends FieldValues>({
         name={fieldName}
         control={control}
         rules={registerOptions}
-        render={({ field: { value, onChange, ...otherFieldProps } }) => {
+        render={({ field: { value, onChange, onBlur: rhfOnBlur, ...otherFieldProps } }) => {
           return (
             <MuiSelect
               {...otherFieldProps}
@@ -129,6 +130,10 @@ const RHFSelect = <T extends FieldValues>({
                 }
               }}
               {...otherSelectProps}
+              onBlur={blurEvent => {
+                rhfOnBlur();
+                onBlur?.(blurEvent);
+              }}
             >
               <MenuItem
                 value=""

--- a/packages/rhf-mui-components/src/mui/slider/index.tsx
+++ b/packages/rhf-mui-components/src/mui/slider/index.tsx
@@ -69,7 +69,7 @@ const RHFSlider = <T extends FieldValues>({
         name={fieldName}
         control={control}
         rules={registerOptions}
-        render={({ field: { onChange, value, onBlur:rhfOnBlur,...otherFieldProps } }) => (
+        render={({ field: { onChange, value, onBlur: rhfOnBlur, ...otherFieldProps } }) => (
           <MuiSlider
             {...otherFieldProps}
             {...rest}
@@ -80,10 +80,10 @@ const RHFSlider = <T extends FieldValues>({
                 onValueChange(value, activeThumb, event);
               }
             }}
-             onBlur={blurEvent => {
-                rhfOnBlur();
-                onBlur?.(blurEvent);
-              }}
+            onBlur={blurEvent => {
+              rhfOnBlur();
+              onBlur?.(blurEvent);
+            }}
           />
         )}
       />

--- a/packages/rhf-mui-components/src/mui/slider/index.tsx
+++ b/packages/rhf-mui-components/src/mui/slider/index.tsx
@@ -50,6 +50,7 @@ const RHFSlider = <T extends FieldValues>({
   errorMessage,
   hideErrorMessage,
   formHelperTextProps,
+  onBlur,
   ...rest
 }: RHFSliderProps<T>) => {
   const fieldLabel = label ?? fieldNameToLabel(fieldName);
@@ -68,7 +69,7 @@ const RHFSlider = <T extends FieldValues>({
         name={fieldName}
         control={control}
         rules={registerOptions}
-        render={({ field: { onChange, value, ...otherFieldProps } }) => (
+        render={({ field: { onChange, value, onBlur:rhfOnBlur,...otherFieldProps } }) => (
           <MuiSlider
             {...otherFieldProps}
             {...rest}
@@ -79,6 +80,10 @@ const RHFSlider = <T extends FieldValues>({
                 onValueChange(value, activeThumb, event);
               }
             }}
+             onBlur={blurEvent => {
+                rhfOnBlur();
+                onBlur?.(blurEvent);
+              }}
           />
         )}
       />

--- a/packages/rhf-mui-components/src/mui/switch/index.tsx
+++ b/packages/rhf-mui-components/src/mui/switch/index.tsx
@@ -45,6 +45,7 @@ const RHFSwitch = <T extends FieldValues>({
   errorMessage,
   hideErrorMessage,
   formHelperTextProps,
+  onBlur,
   ...rest
 }: RHFSwitchProps<T>) => {
   const fieldLabel = label ?? fieldNameToLabel(fieldName);
@@ -63,7 +64,7 @@ const RHFSwitch = <T extends FieldValues>({
       control={control}
       rules={registerOptions}
       render={({ field }) => {
-        const { value, onChange, ...otherFieldParams } = field;
+        const { value, onChange, onBlur:rhfOnBlur, ...otherFieldParams } = field;
         return (
           <Fragment>
             <FormControlLabel
@@ -78,6 +79,10 @@ const RHFSwitch = <T extends FieldValues>({
                       onValueChange(isChecked, event);
                     }
                   }}
+                  onBlur={blurEvent => {{
+                    rhfOnBlur();
+                    onBlur?.(blurEvent);
+                  }}}
                 />
               }
               label={fieldLabel}

--- a/packages/rhf-mui-components/src/mui/switch/index.tsx
+++ b/packages/rhf-mui-components/src/mui/switch/index.tsx
@@ -64,7 +64,7 @@ const RHFSwitch = <T extends FieldValues>({
       control={control}
       rules={registerOptions}
       render={({ field }) => {
-        const { value, onChange, onBlur:rhfOnBlur, ...otherFieldParams } = field;
+        const { value, onChange, onBlur: rhfOnBlur, ...otherFieldParams } = field;
         return (
           <Fragment>
             <FormControlLabel
@@ -79,10 +79,12 @@ const RHFSwitch = <T extends FieldValues>({
                       onValueChange(isChecked, event);
                     }
                   }}
-                  onBlur={blurEvent => {{
-                    rhfOnBlur();
-                    onBlur?.(blurEvent);
-                  }}}
+                  onBlur={blurEvent => {
+                    {
+                      rhfOnBlur();
+                      onBlur?.(blurEvent);
+                    }
+                  }}
                 />
               }
               label={fieldLabel}

--- a/packages/rhf-mui-components/src/mui/tags-input/index.tsx
+++ b/packages/rhf-mui-components/src/mui/tags-input/index.tsx
@@ -177,7 +177,7 @@ const RHFTagsInput = <T extends FieldValues>({
         control={control}
         rules={registerOptions}
         render={({ field }) => {
-          const { value = [], onChange, onBlur:rhfOnBlur } = field;
+          const { value = [], onChange, onBlur: rhfOnBlur } = field;
           const hideInput = disabled && value.length > 0;
           const visibleTags = showAllTags
             ? value

--- a/packages/rhf-mui-components/src/mui/tags-input/index.tsx
+++ b/packages/rhf-mui-components/src/mui/tags-input/index.tsx
@@ -76,6 +76,7 @@ const RHFTagsInput = <T extends FieldValues>({
   limitTags = 2,
   getLimitTagsText,
   slotProps,
+  onBlur,
   ...rest
 }: RHFTagsInputProps<T>) => {
   const muiTheme = useTheme();
@@ -176,7 +177,7 @@ const RHFTagsInput = <T extends FieldValues>({
         control={control}
         rules={registerOptions}
         render={({ field }) => {
-          const { value = [], onChange } = field;
+          const { value = [], onChange, onBlur:rhfOnBlur } = field;
           const hideInput = disabled && value.length > 0;
           const visibleTags = showAllTags
             ? value
@@ -236,7 +237,11 @@ const RHFTagsInput = <T extends FieldValues>({
               }
               value={inputValue}
               onFocus={handleFocus}
-              onBlur={handleBlur}
+              onBlur={blurEvent => {
+                handleBlur();
+                rhfOnBlur();
+                onBlur?.(blurEvent);
+              }}
               onChange={handleInputChange}
               onKeyDown={event => {
                 const newTags = handleKeyPress(event, value);

--- a/packages/rhf-mui-components/src/mui/textfield/index.tsx
+++ b/packages/rhf-mui-components/src/mui/textfield/index.tsx
@@ -40,6 +40,7 @@ const RHFTextField = <T extends FieldValues>({
   errorMessage,
   hideErrorMessage,
   formHelperTextProps,
+  onBlur,
   ...rest
 }: RHFTextFieldProps<T>) => {
   const { allLabelsAboveFields } = useContext(RHFMuiConfigContext);
@@ -64,7 +65,7 @@ const RHFTextField = <T extends FieldValues>({
         control={control}
         rules={registerOptions}
         render={({ field }) => {
-          const { value, onChange, ...otherFieldParams } = field;
+          const { value, onChange, onBlur:rhfOnBlur, ...otherFieldParams } = field;
           return (
             <MuiTextField
               id={fieldName}
@@ -79,9 +80,11 @@ const RHFTextField = <T extends FieldValues>({
               value={value ?? ''}
               onChange={event => {
                 onChange(event);
-                if (onValueChange) {
-                  onValueChange(event.target.value, event);
-                }
+                onValueChange?.(event.target.value, event);
+              }}
+              onBlur={blurEvent => {
+                rhfOnBlur();
+                onBlur?.(blurEvent);
               }}
               error={isError}
               {...rest}

--- a/packages/rhf-mui-components/src/mui/textfield/index.tsx
+++ b/packages/rhf-mui-components/src/mui/textfield/index.tsx
@@ -65,7 +65,7 @@ const RHFTextField = <T extends FieldValues>({
         control={control}
         rules={registerOptions}
         render={({ field }) => {
-          const { value, onChange, onBlur:rhfOnBlur, ...otherFieldParams } = field;
+          const { value, onChange, onBlur: rhfOnBlur, ...otherFieldParams } = field;
           return (
             <MuiTextField
               id={fieldName}

--- a/packages/rhf-mui-components/src/types/mui.ts
+++ b/packages/rhf-mui-components/src/types/mui.ts
@@ -66,7 +66,6 @@ export type SelectProps = Omit<
   | 'onChange'
   | 'value'
   | 'defaultValue'
-  | 'onBlur'
   | 'ref'
 >;
 


### PR DESCRIPTION
- Handle `onBlur` for all fields except for `RHFFileUploader`, `RHFColorPicker`. The blur event for date and time pickers can be passed via `slotProps.textField`.