### PR TITLE
v3.0.2 - RHFMultiAutoComplete bug fixes; add bump-version.sh

### DIFF
--- a/apps/rhf-mui-demo/package.json
+++ b/apps/rhf-mui-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-demo",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "private": true,
   "author": "Nishant Kohli",
   "scripts": {

--- a/apps/rhf-mui-demo/src/forms/autocomplete/index.tsx
+++ b/apps/rhf-mui-demo/src/forms/autocomplete/index.tsx
@@ -126,6 +126,7 @@ const AutocompleteForm = () => {
               control={control}
               options={Object.values(Colors)}
               label="Which colors do you like ?"
+              textFieldProps={{ placeholder: 'Select colors' }}
               registerOptions={{
                 required: {
                   value: true,

--- a/apps/rhf-mui-docs/package.json
+++ b/apps/rhf-mui-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-docs",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/bump-version.sh
+++ b/bump-version.sh
@@ -1,0 +1,46 @@
+## Eg: sh bump-version.sh 3.0.2
+
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: ./bump-version.sh 3.0.2
+VERSION=$1
+
+# Ensure jq is installed for JSON editing
+if ! command -v jq &>/dev/null; then
+  echo "jq not found. Attempting to install..."
+  if command -v brew &>/dev/null; then
+    brew install jq
+  elif command -v apt-get &>/dev/null; then
+    sudo apt-get update && sudo apt-get install -y jq
+  else
+    echo "❌ Could not auto-install jq. Please install it manually:"
+    echo "   macOS: brew install jq"
+    echo "   Ubuntu/Debian: sudo apt-get install jq"
+    exit 1
+  fi
+fi
+
+# Detect package manager
+if [ -f "pnpm-workspace.yaml" ]; then
+  PM="pnpm"
+elif [ -f "yarn.lock" ]; then
+  PM="yarn"
+else
+  echo "❌ Could not detect pnpm or yarn workspace."
+  exit 1
+fi
+
+echo "Bumping all workspace package versions to $VERSION using $PM..."
+
+# Loop through all package.json files in the workspace
+find . -name "package.json" -not -path "*/node_modules/*" | while read -r pkg; do
+  echo "Updating $pkg to version $VERSION"
+  tmp=$(mktemp)
+  jq --arg ver "$VERSION" '.version = $ver' "$pkg" > "$tmp" && mv "$tmp" "$pkg"
+done
+
+# Run install to refresh lockfile
+$PM install
+
+echo "✅ All package versions set to $VERSION"

--- a/changelog/v3.md
+++ b/changelog/v3.md
@@ -5,6 +5,7 @@
 **Released - 18 August, 2025**
 
 - **RHFMultiAutoComplete**: Hide `Select All` option when length of options array is either 0 or 1. Remove placeholder when atleast one option is selected.
+- Add `bump-version.sh` script to increment version of all packages to a specific version.
 
 ## [3.0.1](https://github.com/nishkohli96/rhf-mui-components/tree/v3.0.1)
 

--- a/changelog/v3.md
+++ b/changelog/v3.md
@@ -1,5 +1,11 @@
 # Changelog - v3
 
+## [3.0.2](https://github.com/nishkohli96/rhf-mui-components/tree/v3.0.2)
+
+**Released - 18 August, 2025**
+
+- **RHFMultiAutoComplete**: Hide `Select All` option when length of options array is either 0 or 1. Remove placeholder when atleast one option is selected.
+
 ## [3.0.1](https://github.com/nishkohli96/rhf-mui-components/tree/v3.0.1)
 
 **Released - 2 July, 2025**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-components-root",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "A suite of 20+ reusable mui components for react-hook-form to minimize your time and effort in creating and styling forms",
   "author": "Nishant Kohli",
   "private": true,

--- a/packages/rhf-mui-components/package.json
+++ b/packages/rhf-mui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-components",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "A suite of 20+ reusable Material UI components for React Hook Form to minimize your time and effort in creating and styling forms",
   "author": "Nishant Kohli",
   "homepage": "https://rhf-mui-components.netlify.app/",

--- a/packages/rhf-mui-components/package.json
+++ b/packages/rhf-mui-components/package.json
@@ -24,7 +24,7 @@
     "@mui/material": "^5.0.0 || ^6.0.0 || ^7.0.0",
     "@mui/x-date-pickers": "^6.0.0 || ^7.0.0 || ^8.0.0",
     "react-hook-form": "^7.0.0"
-	},
+  },
   "exports": {
     "./package.json": {
       "import": "./package.json",
@@ -73,14 +73,30 @@
   },
   "typesVersions": {
     "*": {
-      "./mui": ["./mui/index.d.ts"],
-      "./mui/*": ["./mui/*/index.d.ts"],
-      "./mui-pickers": ["./mui-pickers/index.d.ts"],
-      "./mui-pickers/*": ["./mui-pickers/*/index.d.ts"],
-      "./misc": ["./misc/index.d.ts"],
-      "./misc/*": ["./misc/*/index.d.ts"],
-      "./config": ["./config/index.d.ts"],
-      "./form-helpers": ["./form-helpers/index.d.ts"]
+      "./mui": [
+        "./mui/index.d.ts"
+      ],
+      "./mui/*": [
+        "./mui/*/index.d.ts"
+      ],
+      "./mui-pickers": [
+        "./mui-pickers/index.d.ts"
+      ],
+      "./mui-pickers/*": [
+        "./mui-pickers/*/index.d.ts"
+      ],
+      "./misc": [
+        "./misc/index.d.ts"
+      ],
+      "./misc/*": [
+        "./misc/*/index.d.ts"
+      ],
+      "./config": [
+        "./config/index.d.ts"
+      ],
+      "./form-helpers": [
+        "./form-helpers/index.d.ts"
+      ]
     }
   },
   "keywords": [

--- a/packages/rhf-mui-components/src/mui/multi-autocomplete/index.tsx
+++ b/packages/rhf-mui-components/src/mui/multi-autocomplete/index.tsx
@@ -113,6 +113,7 @@ const RHFMultiAutocomplete = <T extends FieldValues>({
   const [selectedValues, setSelectedValues] = useState<StringArr>([]);
   const { allLabelsAboveFields, defaultFormControlLabelSx }
     = useContext(RHFMuiConfigContext);
+  const shouldHideSelectAllOptions = options.length === 0 || options.length === 1;
 
   const { sx, ...otherFormControlLabelProps } = formControlLabelProps ?? {};
   const appliedFormControlLabelSx = {
@@ -134,10 +135,12 @@ const RHFMultiAutocomplete = <T extends FieldValues>({
   }, [selectedValues, options.length]);
 
 
-  const autoCompleteOptions: StrObjOption[] = useMemo(
-    () => [selectAllText, ...options],
-    [options, selectAllText]
-  );
+  const autoCompleteOptions: StrObjOption[] = useMemo(() => {
+    if (shouldHideSelectAllOptions) {
+      return options;
+    }
+    return [selectAllText, ...options];
+  }, [options, selectAllText]);
 
   const isSelectAllOption = useCallback((option: StrObjOption) => {
     return option === selectAllText;
@@ -265,6 +268,9 @@ const RHFMultiAutocomplete = <T extends FieldValues>({
                 return (
                   <TextField
                     {...textFieldProps}
+                    {...(selectedOptions.length > 0 && {
+                      placeholder: undefined
+                    })}
                     {...params}
                     label={
                       !isLabelAboveFormField
@@ -274,13 +280,11 @@ const RHFMultiAutocomplete = <T extends FieldValues>({
                         : undefined
                     }
                     error={isError}
-                    {...(isAboveMuiV5
-                      && {
-                        slotProps: {
-                          htmlInput: textFieldInputProps,
-                        }
+                    {...(isAboveMuiV5 && {
+                      slotProps: {
+                        htmlInput: textFieldInputProps
                       }
-                    )}
+                    })}
                   />
                 );
               }}


### PR DESCRIPTION
- **RHFMultiAutoComplete**: Hide `Select All` option when length of options array is either 0 or 1. Remove placeholder when atleast one option is selected.
- Add `bump-version.sh` script to increment version of all packages to a specific version.