### PR TITLE
v3.1.2 - RHFSelect: Fix renderValue logic

### DIFF
--- a/apps/rhf-mui-demo/package.json
+++ b/apps/rhf-mui-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-demo",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "private": true,
   "author": "Nishant Kohli",
   "scripts": {

--- a/apps/rhf-mui-docs/package.json
+++ b/apps/rhf-mui-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-docs",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/apps/rhf-mui-docs/src/page-components/mui/select/RHFSelect.tsx
+++ b/apps/rhf-mui-docs/src/page-components/mui/select/RHFSelect.tsx
@@ -39,7 +39,6 @@ const RHFSelectPropsTable = ({ v1, v3_1AndAbove }: VersionProps) => {
     <MarkdownTable
       rows={tableRows}
       showType
-      deprecatedKeys={['showDefaultOption', 'defaultOptionText']}
     />
   );
 };

--- a/changelog/v3.md
+++ b/changelog/v3.md
@@ -1,8 +1,18 @@
 # Changelog - v3
 
+## [3.1.2](https://github.com/nishkohli96/rhf-mui-components/tree/v3.1.2)
+
+**Released - 11 December, 2025**
+
+### RHFSelect Fixes
+- Correct `renderValue` logic which was rendering value(s) instead of label in the **Select** field.
+- Deprecation removed for `showDefaultOption` & `defaultOptionText` props
+
 ## [3.1.1](https://github.com/nishkohli96/rhf-mui-components/tree/v3.1.1)
 
 **Released - 10 December, 2025**
+
+- Update **README.md** of the package
 
 ## [3.1.0](https://github.com/nishkohli96/rhf-mui-components/tree/v3.1.0)
 

--- a/changelog/v3.md
+++ b/changelog/v3.md
@@ -1,5 +1,9 @@
 # Changelog - v3
 
+## [3.1.1](https://github.com/nishkohli96/rhf-mui-components/tree/v3.1.1)
+
+**Released - 10 December, 2025**
+
 ## [3.1.0](https://github.com/nishkohli96/rhf-mui-components/tree/v3.1.0)
 
 **Released - 10 December, 2025**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-components-root",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "A suite of 20+ reusable mui components for react-hook-form to minimize your time and effort in creating and styling forms",
   "author": "Nishant Kohli",
   "private": true,

--- a/packages/rhf-mui-components/package.json
+++ b/packages/rhf-mui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-components",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "A suite of 20+ reusable Material UI components for React Hook Form to minimize your time and effort in creating and styling forms",
   "author": "Nishant Kohli",
   "homepage": "https://rhf-mui-components.netlify.app/",

--- a/packages/rhf-mui-components/src/mui/select/index.tsx
+++ b/packages/rhf-mui-components/src/mui/select/index.tsx
@@ -38,19 +38,7 @@ export type RHFSelectProps<T extends FieldValues> = {
   options: StrNumObjOption[];
   labelKey?: string;
   valueKey?: string;
-  /**
-   * @deprecated
-   * This prop will be removed in the next major update.
-   * Use `placeholder` prop instead to show placeholder text when
-   * no option is selected.
-   */
   showDefaultOption?: boolean;
-  /**
-   * @deprecated
-   * This prop will be removed in the next major update.
-   * Use `placeholder` prop instead to show placeholder text when
-   * no option is selected.
-   */
   defaultOptionText?: string;
   onValueChange?: (
     newValue: SelectValueType,
@@ -158,14 +146,39 @@ const RHFSelect = <T extends FieldValues>({
                   rhfOnBlur();
                   onBlur?.(blurEvent);
                 }}
-                renderValue={value => {
+                renderValue={(value: SelectValueType) => {
                   if (showPlaceholder) {
                     return placeholder;
                   }
-                  if (multiple) {
-                    return renderValue?.(value) ?? value.join(', ');
+                  /* For multiple options */
+                  if (Array.isArray(value)) {
+                    const labels = value.map((val) => {
+                      const match = options.find((op) =>
+                        isKeyValueOption(op, labelKey, valueKey)
+                          ? `${op[valueKey!]}` === `${val}`
+                          : op === val
+                      );
+                      return isKeyValueOption(match!, labelKey, valueKey)
+                        ? match[labelKey!]
+                        : match;
+                    });
+                    return renderValue?.(value) ?? labels.join(', ');
                   }
-                  return renderValue?.(value) ?? value;
+
+                  /* For single option */
+                  const match = options.find((op) =>
+                    isKeyValueOption(op, labelKey, valueKey)
+                      ? `${op[valueKey!]}` === `${value}`
+                      : op === value
+                  );
+                  const optionLabel = isKeyValueOption(
+                    match!,
+                    labelKey,
+                    valueKey
+                  )
+                    ? match[labelKey!]
+                    : match;
+                  return renderValue?.(value) ?? optionLabel;
                 }}
               >
                 <MenuItem


### PR DESCRIPTION
### RHFSelect Fixes
- Correct `renderValue` logic which was rendering value(s) instead of label in the **Select** field.
- Deprecation removed for `showDefaultOption` & `defaultOptionText` props