### PR TITLE
v3.1.3 - Enable renderOption prop in RHFAutocomplete

### DIFF
--- a/apps/rhf-mui-demo/package.json
+++ b/apps/rhf-mui-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-demo",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "private": true,
   "author": "Nishant Kohli",
   "scripts": {

--- a/apps/rhf-mui-demo/src/forms/autocomplete/index.tsx
+++ b/apps/rhf-mui-demo/src/forms/autocomplete/index.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react';
 import { usePathname } from 'next/navigation';
 import { useForm } from 'react-hook-form';
 import { faker } from '@faker-js/faker';
+import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid2';
 import Typography from '@mui/material/Typography';
 import RHFCountrySelect, { countryList, type CountryISO } from '@nish1896/rhf-mui-components/mui/country-select';
@@ -86,6 +87,52 @@ const AutocompleteForm = () => {
                 }
               }}
               options={airportList}
+              // @ts-ignore
+              renderOption={(props, option: AirportInfo) => {
+                const { key, ...optionProps } = props;
+                return (
+                  <Box
+                    key={key}
+                    component="li"
+                    {...optionProps}
+                    sx={{
+                      px: 1.25,
+                      py: 0.5,
+                      borderRadius: 1,
+                      display: 'flex',
+                      flexDirection: 'column',
+                      textAlign: 'left',
+                      // 🔥 CRITICAL OVERRIDE
+                      '&.MuiAutocomplete-option': {
+                        alignItems: 'flex-start',
+                        justifyContent: 'flex-start'
+                      },
+                      minHeight: 'unset !important',
+                      '&:hover': {
+                        backgroundColor: 'action.hover'
+                      },
+                      '&[aria-selected="true"]': {
+                        backgroundColor: 'action.selected'
+                      }
+                    }}
+                  >
+                    <Box
+                      sx={{ fontSize: 14, fontWeight: 600, lineHeight: 1.2 }}
+                    >
+                      {option.name}
+                    </Box>
+                    <Box
+                      sx={{
+                        fontSize: 12,
+                        lineHeight: 1.2,
+                        color: 'text.secondary'
+                      }}
+                    >
+                      {option.iataCode}
+                    </Box>
+                  </Box>
+                );
+              }}
               labelKey="name"
               valueKey="iataCode"
               required
@@ -133,7 +180,7 @@ const AutocompleteForm = () => {
                   message: 'This field is required'
                 },
                 validate: {
-                  minItems: value => {
+                  minItems: (value) => {
                     if (Array.isArray(value)) {
                       return value.length >= 2
                         ? true
@@ -143,7 +190,7 @@ const AutocompleteForm = () => {
                   }
                 }
               }}
-              getLimitTagsText={more => `+${more} Color(s)`}
+              getLimitTagsText={(more) => `+${more} Color(s)`}
               helperText="Select at least 2 colors"
               formControlLabelProps={{ sx: { color: 'royalblue' } }}
               errorMessage={errors?.colors?.message}
@@ -165,7 +212,7 @@ const AutocompleteForm = () => {
                   message: 'This field is required'
                 },
                 validate: {
-                  minItems: value => {
+                  minItems: (value) => {
                     if (Array.isArray(value)) {
                       return value.length >= 2
                         ? true
@@ -180,7 +227,7 @@ const AutocompleteForm = () => {
               ChipProps={{
                 sx: {
                   bgcolor: '#006699',
-                  color: theme => theme.palette.secondary.main
+                  color: (theme) => theme.palette.secondary.main
                 }
               }}
               required
@@ -225,10 +272,10 @@ const AutocompleteForm = () => {
                   message: 'This field is required'
                 },
                 validate: {
-                  minItems: value => {
+                  minItems: (value) => {
                     if (
-                      Array.isArray(value)
-                      && value.every(item => typeof item === 'string')
+                      Array.isArray(value) &&
+                      value.every((item) => typeof item === 'string')
                     ) {
                       return value.length >= 3 || 'Select at least 3 countries';
                     }
@@ -244,7 +291,7 @@ const AutocompleteForm = () => {
               label="What are your Dream Destinations?"
               ChipProps={{
                 sx: {
-                  background: theme => theme.palette.primary.main
+                  background: (theme) => theme.palette.primary.main
                 }
               }}
               helperText={

--- a/apps/rhf-mui-demo/src/forms/autocomplete/index.tsx
+++ b/apps/rhf-mui-demo/src/forms/autocomplete/index.tsx
@@ -89,12 +89,10 @@ const AutocompleteForm = () => {
               options={airportList}
               // @ts-ignore
               renderOption={(props, option: AirportInfo) => {
-                const { key, ...optionProps } = props;
                 return (
                   <Box
-                    key={key}
                     component="li"
-                    {...optionProps}
+                    {...props}
                     sx={{
                       px: 1.25,
                       py: 0.5,
@@ -180,7 +178,7 @@ const AutocompleteForm = () => {
                   message: 'This field is required'
                 },
                 validate: {
-                  minItems: (value) => {
+                  minItems: value => {
                     if (Array.isArray(value)) {
                       return value.length >= 2
                         ? true
@@ -190,7 +188,7 @@ const AutocompleteForm = () => {
                   }
                 }
               }}
-              getLimitTagsText={(more) => `+${more} Color(s)`}
+              getLimitTagsText={more => `+${more} Color(s)`}
               helperText="Select at least 2 colors"
               formControlLabelProps={{ sx: { color: 'royalblue' } }}
               errorMessage={errors?.colors?.message}
@@ -212,7 +210,7 @@ const AutocompleteForm = () => {
                   message: 'This field is required'
                 },
                 validate: {
-                  minItems: (value) => {
+                  minItems: value => {
                     if (Array.isArray(value)) {
                       return value.length >= 2
                         ? true
@@ -227,7 +225,7 @@ const AutocompleteForm = () => {
               ChipProps={{
                 sx: {
                   bgcolor: '#006699',
-                  color: (theme) => theme.palette.secondary.main
+                  color: theme => theme.palette.secondary.main
                 }
               }}
               required
@@ -272,10 +270,10 @@ const AutocompleteForm = () => {
                   message: 'This field is required'
                 },
                 validate: {
-                  minItems: (value) => {
+                  minItems: value => {
                     if (
-                      Array.isArray(value) &&
-                      value.every((item) => typeof item === 'string')
+                      Array.isArray(value)
+                      && value.every(item => typeof item === 'string')
                     ) {
                       return value.length >= 3 || 'Select at least 3 countries';
                     }
@@ -291,7 +289,7 @@ const AutocompleteForm = () => {
               label="What are your Dream Destinations?"
               ChipProps={{
                 sx: {
-                  background: (theme) => theme.palette.primary.main
+                  background: theme => theme.palette.primary.main
                 }
               }}
               helperText={

--- a/apps/rhf-mui-demo/src/forms/autocomplete/index.tsx
+++ b/apps/rhf-mui-demo/src/forms/autocomplete/index.tsx
@@ -76,7 +76,7 @@ const AutocompleteForm = () => {
       <form onSubmit={handleSubmit(onFormSubmit)}>
         <GridContainer>
           <Grid size={{ xs: 12, md: 6 }}>
-            <FieldVariantInfo title="Autocomplete" />
+            <FieldVariantInfo title="Autocomplete with custom renderOption" />
             <RHFAutocomplete
               fieldName="sourceAirport"
               control={control}

--- a/apps/rhf-mui-docs/package.json
+++ b/apps/rhf-mui-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-docs",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/changelog/v3.md
+++ b/changelog/v3.md
@@ -1,5 +1,12 @@
 # Changelog - v3
 
+## [3.1.3](https://github.com/nishkohli96/rhf-mui-components/tree/v3.1.3)
+
+**Released - 17 December, 2025**
+
+### RHFAutocomplete Fixes
+- The `renderOption` prop is now supported, allowing developers to fully customize how options are rendered. A relevant example with code snippet has also been provided.
+
 ## [3.1.2](https://github.com/nishkohli96/rhf-mui-components/tree/v3.1.2)
 
 **Released - 11 December, 2025**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-components-root",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "A suite of 20+ reusable mui components for react-hook-form to minimize your time and effort in creating and styling forms",
   "author": "Nishant Kohli",
   "private": true,

--- a/packages/rhf-mui-components/package.json
+++ b/packages/rhf-mui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-components",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "A suite of 20+ reusable Material UI components for React Hook Form to minimize your time and effort in creating and styling forms",
   "author": "Nishant Kohli",
   "homepage": "https://rhf-mui-components.netlify.app/",

--- a/packages/rhf-mui-components/src/mui/autocomplete/index.tsx
+++ b/packages/rhf-mui-components/src/mui/autocomplete/index.tsx
@@ -45,7 +45,6 @@ type OmittedAutocompleteProps = Omit<
   | 'freeSolo'
   | 'fullWidth'
   | 'renderInput'
-  | 'renderOption'
   | 'options'
   | 'value'
   | 'defaultValue'

--- a/packages/rhf-mui-components/src/mui/select/index.tsx
+++ b/packages/rhf-mui-components/src/mui/select/index.tsx
@@ -152,12 +152,11 @@ const RHFSelect = <T extends FieldValues>({
                   }
                   /* For multiple options */
                   if (Array.isArray(value)) {
-                    const labels = value.map((val) => {
-                      const match = options.find((op) =>
+                    const labels = value.map(val => {
+                      const match = options.find(op =>
                         isKeyValueOption(op, labelKey, valueKey)
                           ? `${op[valueKey!]}` === `${val}`
-                          : op === val
-                      );
+                          : op === val);
                       return isKeyValueOption(match!, labelKey, valueKey)
                         ? match[labelKey!]
                         : match;
@@ -166,11 +165,10 @@ const RHFSelect = <T extends FieldValues>({
                   }
 
                   /* For single option */
-                  const match = options.find((op) =>
+                  const match = options.find(op =>
                     isKeyValueOption(op, labelKey, valueKey)
                       ? `${op[valueKey!]}` === `${value}`
-                      : op === value
-                  );
+                      : op === value);
                   const optionLabel = isKeyValueOption(
                     match!,
                     labelKey,


### PR DESCRIPTION
### RHFAutocomplete Fixes
- The `renderOption` prop is now supported, allowing developers to fully customize how options are rendered. A relevant example with code snippet has also been provided.