### PR TITLE
v3.1.4 - Fix Autocomplete loader missing during loading state

### DIFF
--- a/apps/rhf-mui-demo/package.json
+++ b/apps/rhf-mui-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-demo",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "private": true,
   "author": "Nishant Kohli",
   "scripts": {

--- a/apps/rhf-mui-docs/package.json
+++ b/apps/rhf-mui-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-docs",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/changelog/v3.md
+++ b/changelog/v3.md
@@ -1,5 +1,13 @@
 # Changelog - v3
 
+## [3.1.4](https://github.com/nishkohli96/rhf-mui-components/tree/v3.1.4)
+
+**Released - 25 December, 2025**
+
+### Autocomplete Fixes
+- Enable `inputProps` and `slotProps` for `RHFAutocomplete` and `RHFMultiAutocomplete`.
+- Fixed an issue where the loading spinner was not displayed in Autocomplete components when the `loading` prop was set to *true*.
+
 ## [3.1.3](https://github.com/nishkohli96/rhf-mui-components/tree/v3.1.3)
 
 **Released - 17 December, 2025**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-components-root",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "A suite of 20+ reusable mui components for react-hook-form to minimize your time and effort in creating and styling forms",
   "author": "Nishant Kohli",
   "private": true,

--- a/packages/rhf-mui-components/package.json
+++ b/packages/rhf-mui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-components",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "A suite of 20+ reusable Material UI components for React Hook Form to minimize your time and effort in creating and styling forms",
   "author": "Nishant Kohli",
   "homepage": "https://rhf-mui-components.netlify.app/",

--- a/packages/rhf-mui-components/src/mui/autocomplete/index.tsx
+++ b/packages/rhf-mui-components/src/mui/autocomplete/index.tsx
@@ -17,6 +17,7 @@ import Autocomplete, {
 } from '@mui/material/Autocomplete';
 import TextField from '@mui/material/TextField';
 import Chip from '@mui/material/Chip';
+import CircularProgress from '@mui/material/CircularProgress';
 import { RHFMuiConfigContext } from '@/config/ConfigProvider';
 import {
   FormControl,
@@ -104,6 +105,7 @@ const RHFAutocomplete = <T extends FieldValues>({
   slotProps,
   ChipProps,
   onBlur,
+  loading,
   ...otherAutoCompleteProps
 }: RHFAutocompleteProps<T>) => {
   validateArray('RHFAutocomplete', options, labelKey, valueKey);
@@ -155,6 +157,7 @@ const RHFAutocomplete = <T extends FieldValues>({
               options={options}
               multiple={multiple}
               value={selectedOptions}
+              loading={loading}
               autoHighlight
               blurOnSelect={!multiple}
               disableCloseOnSelect={multiple}
@@ -225,13 +228,42 @@ const RHFAutocomplete = <T extends FieldValues>({
                     {...(isAboveMuiV5
                       ? {
                         slotProps: {
+                          ...textFieldProps?.slotProps,
+                          input: {
+                            ...params?.InputProps,
+                            ...textFieldProps?.slotProps?.input,
+                            endAdornment: (
+                              <>
+                                {loading
+                                  ? (
+                                    <CircularProgress
+                                      color="inherit"
+                                      size={20}
+                                    />
+                                  )
+                                  : <></>}
+                                {params.InputProps.endAdornment}
+                              </>
+                            )
+                          },
                           htmlInput: textFieldInputProps
                         }
                       }
                       : {
+                        InputProps: {
+                          ...params.InputProps,
+                          ...textFieldProps?.InputProps,
+                          endAdornment: (
+                            <>
+                              {loading && (
+                                <CircularProgress color="inherit" size={20} />
+                              )}
+                              {params.InputProps.endAdornment}
+                            </>
+                          ),
+                        },
                         inputProps: textFieldInputProps
-                      }
-                    )}
+                      })}
                   />
                 );
               }}

--- a/packages/rhf-mui-components/src/mui/multi-autocomplete/index.tsx
+++ b/packages/rhf-mui-components/src/mui/multi-autocomplete/index.tsx
@@ -18,6 +18,7 @@ import TextField from '@mui/material/TextField';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Checkbox from '@mui/material/Checkbox';
 import Chip from '@mui/material/Chip';
+import CircularProgress from '@mui/material/CircularProgress';
 import { RHFMuiConfigContext } from '@/config/ConfigProvider';
 import { FormControl, FormLabel, FormLabelText, FormHelperText } from '@/mui/common';
 import type {
@@ -106,6 +107,7 @@ const RHFMultiAutocomplete = <T extends FieldValues>({
   slotProps,
   ChipProps,
   onBlur,
+  loading,
   ...otherAutoCompleteProps
 }: RHFMultiAutocompleteProps<T>) => {
   validateArray('RHFMultiAutocomplete', options, labelKey, valueKey);
@@ -216,6 +218,7 @@ const RHFMultiAutocomplete = <T extends FieldValues>({
               id={fieldName}
               options={autoCompleteOptions}
               value={selectedOptions}
+              loading={loading}
               fullWidth
               multiple
               autoHighlight
@@ -280,11 +283,45 @@ const RHFMultiAutocomplete = <T extends FieldValues>({
                         : undefined
                     }
                     error={isError}
-                    {...(isAboveMuiV5 && {
-                      slotProps: {
-                        htmlInput: textFieldInputProps
+                    {...(isAboveMuiV5
+                      ? {
+                        slotProps: {
+                          ...textFieldProps?.slotProps,
+                          input: {
+                            ...params?.InputProps,
+                            ...textFieldProps?.slotProps?.input,
+                            endAdornment: (
+                              <>
+                                {loading
+                                  ? (
+                                    <CircularProgress
+                                      color="inherit"
+                                      size={20}
+                                    />
+                                  )
+                                  : <></>}
+                                {params.InputProps.endAdornment}
+                              </>
+                            )
+                          },
+                          htmlInput: textFieldInputProps
+                        }
                       }
-                    })}
+                      : {
+                        InputProps: {
+                          ...params.InputProps,
+                          ...textFieldProps?.InputProps,
+                          endAdornment: (
+                            <>
+                              {loading && (
+                                <CircularProgress color="inherit" size={20} />
+                              )}
+                              {params.InputProps.endAdornment}
+                            </>
+                          ),
+                        },
+                        inputProps: textFieldInputProps
+                      })}
                   />
                 );
               }}

--- a/packages/rhf-mui-components/src/types/mui.ts
+++ b/packages/rhf-mui-components/src/types/mui.ts
@@ -75,8 +75,6 @@ export type AutoCompleteTextFieldProps = Omit<
   | 'value'
   | 'onChange'
   | 'disabled'
-  | 'inputProps'
-  | 'slotProps'
   | 'label'
   | 'required'
   | 'error'


### PR DESCRIPTION
### Autocomplete Fixes
- Enable `inputProps` and `slotProps` for `RHFAutocomplete` and `RHFMultiAutocomplete`.
- Fixed an issue where the loading spinner was not displayed in Autocomplete components when the `loading` prop was set to *true*.