### PR TITLE
v4.1.2 - Update fieldErrorMessage logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ yarn-debug.log*
 yarn-error.log*
 
 publish-pkg.sh
+
+# AI Agents
+.claude

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,8 +6,6 @@ We as members, contributors, and maintainers of **@nish1896/rhf-mui-components**
 
 We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
 
----
-
 ## Our Standards
 
 Examples of behavior that contributes to a positive environment include:
@@ -26,16 +24,12 @@ Examples of unacceptable behavior include:
 - Publishing others' private information without permission
 - Any conduct that could reasonably be considered inappropriate in a professional setting
 
----
-
 ## Enforcement Responsibilities
 
 Project maintainers are responsible for clarifying and enforcing our standards of acceptable behavior.  
 They may take appropriate and fair corrective action in response to behavior deemed inappropriate, threatening, offensive, or harmful.
 
 Maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, issues, and other contributions that are not aligned with this Code of Conduct.
-
----
 
 ## Scope
 
@@ -49,16 +43,12 @@ This Code of Conduct applies within all project spaces, including:
 
 It also applies when an individual is officially representing the project in public spaces.
 
----
-
 ## Reporting
 
 If you experience or witness unacceptable behavior, please report it by opening a private issue or contacting the maintainers directly.
 
 All reports will be reviewed and investigated promptly and fairly.  
 Maintainers are obligated to respect the privacy and security of the reporter.
-
----
 
 ## Enforcement Guidelines
 
@@ -69,8 +59,6 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may result i
 - Permanent removal from the project community
 
 The severity of enforcement will depend on the circumstances of the violation.
-
----
 
 ## Attribution
 

--- a/changelog/v4.md
+++ b/changelog/v4.md
@@ -2,7 +2,7 @@
 
 ## [4.1.1](https://github.com/nishkohli96/rhf-mui-components/tree/v4.1.1)
 
-**Released — 7 July, 2026**
+**Released — 8 July, 2026**
 
 ### 🐞 Bug Fixes
 - Corrected field error resolution to prefer `renderError`, then legacy `errorMessage`, then RHF-derived error messages.

--- a/changelog/v4.md
+++ b/changelog/v4.md
@@ -4,6 +4,14 @@
 
 **Released — 7 July, 2026**
 
+### 🐞 Bug Fixes
+- Corrected field error resolution to prefer `renderError`, then legacy `errorMessage`, then RHF-derived error messages.
+
+
+## [4.1.1](https://github.com/nishkohli96/rhf-mui-components/tree/v4.1.1)
+
+**Released — 7 July, 2026**
+
 ### ⚙️ Project & Tooling
 - Moved internal component/helper types into `@/common/types`, keeping `@/types` focused on public package types only.
 - Remove examples link from `v1` and `v2` docs.
@@ -17,9 +25,6 @@
 - Added **StackBlitz** playground link to the docs website header.
 - Adjust dimensions of appbar logo for both docs and demo website.
 - Documented `renderError` in the deprecated `errorMessage` JSDoc as the replacement for custom error rendering.
-
-### 🐞 Bug Fixes
-- Corrected field error resolution to prefer `renderError`, then legacy `errorMessage`, then RHF-derived error messages.
 
 
 ## [4.1.0](https://github.com/nishkohli96/rhf-mui-components/tree/v4.1.0)

--- a/packages/rhf-mui-components/src/misc/color-picker/index.tsx
+++ b/packages/rhf-mui-components/src/misc/color-picker/index.tsx
@@ -233,10 +233,9 @@ const RHFColorPicker = <T extends FieldValues>({
         fieldState: { error: fieldStateError }
       }) => {
         const isDisabled = muiDisabled || rhfDisabled;
-        const fieldErrorMessage
-          = fieldStateError
-            ? renderError?.(fieldStateError) ?? fieldStateError.message?.toString()
-            : errorMessage;
+        const fieldErrorMessage = fieldStateError
+          ? (renderError?.(fieldStateError) ?? errorMessage ?? fieldStateError.message?.toString())
+          : undefined;
         const isError = !!fieldErrorMessage;
         const showHelperTextElement = !!(
           helperText

--- a/packages/rhf-mui-components/src/misc/rich-text-editor/index.tsx
+++ b/packages/rhf-mui-components/src/misc/rich-text-editor/index.tsx
@@ -254,10 +254,9 @@ const RHFRichTextEditorInner = forwardRef(function RHFRichTextEditorInner<
         fieldState: { error: fieldStateError }
       }) => {
         const isDisabled = muiDisabled || rhfDisabled;
-        const fieldErrorMessage
-          = fieldStateError
-            ? renderError?.(fieldStateError) ?? fieldStateError.message?.toString()
-            : errorMessage;
+        const fieldErrorMessage = fieldStateError
+          ? (renderError?.(fieldStateError) ?? errorMessage ?? fieldStateError.message?.toString())
+          : undefined;
         const isError = !!fieldErrorMessage;
         const showHelperTextElement = !!(
           helperText

--- a/packages/rhf-mui-components/src/mui-pickers/date-time/RHFDateTimePicker.tsx
+++ b/packages/rhf-mui-components/src/mui-pickers/date-time/RHFDateTimePicker.tsx
@@ -213,10 +213,9 @@ const RHFDateTimePickerInner = forwardRef(function RHFDateTimePicker<
           fieldState: { error: fieldStateError }
         }) => {
           const isDisabled = muiDisabled || rhfDisabled;
-          const fieldErrorMessage
-            = fieldStateError
-              ? renderError?.(fieldStateError) ?? fieldStateError.message?.toString()
-              : errorMessage;
+          const fieldErrorMessage = fieldStateError
+            ? (renderError?.(fieldStateError) ?? errorMessage ?? fieldStateError.message?.toString())
+            : undefined;
           const isError = !!fieldErrorMessage;
           const showHelperTextElement = !!(
             helperText

--- a/packages/rhf-mui-components/src/mui-pickers/date-time/RHFDesktopDateTimePicker.tsx
+++ b/packages/rhf-mui-components/src/mui-pickers/date-time/RHFDesktopDateTimePicker.tsx
@@ -213,10 +213,9 @@ const RHFDesktopDateTimePickerInner = forwardRef(function RHFDesktopDateTimePick
           fieldState: { error: fieldStateError }
         }) => {
           const isDisabled = muiDisabled || rhfDisabled;
-          const fieldErrorMessage
-            = fieldStateError
-              ? renderError?.(fieldStateError) ?? fieldStateError.message?.toString()
-              : errorMessage;
+          const fieldErrorMessage = fieldStateError
+            ? (renderError?.(fieldStateError) ?? errorMessage ?? fieldStateError.message?.toString())
+            : undefined;
           const isError = !!fieldErrorMessage;
           const showHelperTextElement = !!(
             helperText

--- a/packages/rhf-mui-components/src/mui-pickers/date-time/RHFMobileDateTimePicker.tsx
+++ b/packages/rhf-mui-components/src/mui-pickers/date-time/RHFMobileDateTimePicker.tsx
@@ -213,10 +213,9 @@ const RHFMobileDateTimePickerInner = forwardRef(function RHFMobileDateTimePicker
           fieldState: { error: fieldStateError }
         }) => {
           const isDisabled = muiDisabled || rhfDisabled;
-          const fieldErrorMessage
-            = fieldStateError
-              ? renderError?.(fieldStateError) ?? fieldStateError.message?.toString()
-              : errorMessage;
+          const fieldErrorMessage = fieldStateError
+            ? (renderError?.(fieldStateError) ?? errorMessage ?? fieldStateError.message?.toString())
+            : undefined;
           const isError = !!fieldErrorMessage;
           const showHelperTextElement = !!(
             helperText

--- a/packages/rhf-mui-components/src/mui-pickers/date-time/RHFStaticDateTimePicker.tsx
+++ b/packages/rhf-mui-components/src/mui-pickers/date-time/RHFStaticDateTimePicker.tsx
@@ -213,10 +213,9 @@ const RHFStaticDateTimePickerInner = forwardRef(
             fieldState: { error: fieldStateError }
           }) => {
             const isDisabled = muiDisabled || rhfDisabled;
-            const fieldErrorMessage
-              = fieldStateError
-                ? renderError?.(fieldStateError) ?? fieldStateError.message?.toString()
-                : errorMessage;
+            const fieldErrorMessage = fieldStateError
+              ? (renderError?.(fieldStateError) ?? errorMessage ?? fieldStateError.message?.toString())
+              : undefined;
             const isError = !!fieldErrorMessage;
             const showHelperTextElement = !!(
               helperText

--- a/packages/rhf-mui-components/src/mui-pickers/date/RHFDatePicker.tsx
+++ b/packages/rhf-mui-components/src/mui-pickers/date/RHFDatePicker.tsx
@@ -215,10 +215,9 @@ const RHFDatePickerInner = forwardRef(function RHFDatePicker<T extends FieldValu
           fieldState: { error: fieldStateError }
         }) => {
           const isDisabled = muiDisabled || rhfDisabled;
-          const fieldErrorMessage
-            = fieldStateError
-              ? renderError?.(fieldStateError) ?? fieldStateError.message?.toString()
-              : errorMessage;
+          const fieldErrorMessage = fieldStateError
+            ? (renderError?.(fieldStateError) ?? errorMessage ?? fieldStateError.message?.toString())
+            : undefined;
           const isError = !!fieldErrorMessage;
           const showHelperTextElement = !!(
             helperText

--- a/packages/rhf-mui-components/src/mui-pickers/date/RHFDesktopDatePicker.tsx
+++ b/packages/rhf-mui-components/src/mui-pickers/date/RHFDesktopDatePicker.tsx
@@ -213,10 +213,9 @@ const RHFDesktopDatePickerInner = forwardRef(function RHFDesktopDatePicker<
           fieldState: { error: fieldStateError }
         }) => {
           const isDisabled = muiDisabled || rhfDisabled;
-          const fieldErrorMessage
-            = fieldStateError
-              ? renderError?.(fieldStateError) ?? fieldStateError.message?.toString()
-              : errorMessage;
+          const fieldErrorMessage = fieldStateError
+            ? (renderError?.(fieldStateError) ?? errorMessage ?? fieldStateError.message?.toString())
+            : undefined;
           const isError = !!fieldErrorMessage;
           const showHelperTextElement = !!(
             helperText

--- a/packages/rhf-mui-components/src/mui-pickers/date/RHFMobileDatePicker.tsx
+++ b/packages/rhf-mui-components/src/mui-pickers/date/RHFMobileDatePicker.tsx
@@ -213,10 +213,9 @@ const RHFMobileDatePickerInner = forwardRef(function RHFMobileDatePicker<
           fieldState: { error: fieldStateError }
         }) => {
           const isDisabled = muiDisabled || rhfDisabled;
-          const fieldErrorMessage
-            = fieldStateError
-              ? renderError?.(fieldStateError) ?? fieldStateError.message?.toString()
-              : errorMessage;
+          const fieldErrorMessage = fieldStateError
+            ? (renderError?.(fieldStateError) ?? errorMessage ?? fieldStateError.message?.toString())
+            : undefined;
           const isError = !!fieldErrorMessage;
           const showHelperTextElement = !!(
             helperText

--- a/packages/rhf-mui-components/src/mui-pickers/date/RHFStaticDatePicker.tsx
+++ b/packages/rhf-mui-components/src/mui-pickers/date/RHFStaticDatePicker.tsx
@@ -213,10 +213,9 @@ const RHFStaticDatePickerInner = forwardRef(function RHFStaticDatePicker<
           fieldState: { error: fieldStateError }
         }) => {
           const isDisabled = muiDisabled || rhfDisabled;
-          const fieldErrorMessage
-            = fieldStateError
-              ? renderError?.(fieldStateError) ?? fieldStateError.message?.toString()
-              : errorMessage;
+          const fieldErrorMessage = fieldStateError
+            ? (renderError?.(fieldStateError) ?? errorMessage ?? fieldStateError.message?.toString())
+            : undefined;
           const isError = !!fieldErrorMessage;
           const showHelperTextElement = !!(
             helperText

--- a/packages/rhf-mui-components/src/mui-pickers/time/RHFDesktopTimePicker.tsx
+++ b/packages/rhf-mui-components/src/mui-pickers/time/RHFDesktopTimePicker.tsx
@@ -213,10 +213,9 @@ const RHFDesktopTimePickerInner = forwardRef(function RHFDesktopTimePicker<
           fieldState: { error: fieldStateError }
         }) => {
           const isDisabled = muiDisabled || rhfDisabled;
-          const fieldErrorMessage
-            = fieldStateError
-              ? renderError?.(fieldStateError) ?? fieldStateError.message?.toString()
-              : errorMessage;
+          const fieldErrorMessage = fieldStateError
+            ? (renderError?.(fieldStateError) ?? errorMessage ?? fieldStateError.message?.toString())
+            : undefined;
           const isError = !!fieldErrorMessage;
           const showHelperTextElement = !!(
             helperText

--- a/packages/rhf-mui-components/src/mui-pickers/time/RHFMobileTimePicker.tsx
+++ b/packages/rhf-mui-components/src/mui-pickers/time/RHFMobileTimePicker.tsx
@@ -213,10 +213,9 @@ const RHFMobileTimePickerInner = forwardRef(function RHFMobileTimePicker<
           fieldState: { error: fieldStateError }
         }) => {
           const isDisabled = muiDisabled || rhfDisabled;
-          const fieldErrorMessage
-            = fieldStateError
-              ? renderError?.(fieldStateError) ?? fieldStateError.message?.toString()
-              : errorMessage;
+          const fieldErrorMessage = fieldStateError
+            ? (renderError?.(fieldStateError) ?? errorMessage ?? fieldStateError.message?.toString())
+            : undefined;
           const isError = !!fieldErrorMessage;
           const showHelperTextElement = !!(
             helperText

--- a/packages/rhf-mui-components/src/mui-pickers/time/RHFStaticTimePicker.tsx
+++ b/packages/rhf-mui-components/src/mui-pickers/time/RHFStaticTimePicker.tsx
@@ -213,10 +213,9 @@ const RHFStaticTimePickerInner = forwardRef(function RHFStaticTimePicker<
           fieldState: { error: fieldStateError }
         }) => {
           const isDisabled = muiDisabled || rhfDisabled;
-          const fieldErrorMessage
-            = fieldStateError
-              ? renderError?.(fieldStateError) ?? fieldStateError.message?.toString()
-              : errorMessage;
+          const fieldErrorMessage = fieldStateError
+            ? (renderError?.(fieldStateError) ?? errorMessage ?? fieldStateError.message?.toString())
+            : undefined;
           const isError = !!fieldErrorMessage;
           const showHelperTextElement = !!(
             helperText

--- a/packages/rhf-mui-components/src/mui-pickers/time/RHFTimePicker.tsx
+++ b/packages/rhf-mui-components/src/mui-pickers/time/RHFTimePicker.tsx
@@ -213,10 +213,9 @@ ref: Ref<HTMLInputElement>) {
           fieldState: { error: fieldStateError }
         }) => {
           const isDisabled = muiDisabled || rhfDisabled;
-          const fieldErrorMessage
-            = fieldStateError
-              ? renderError?.(fieldStateError) ?? fieldStateError.message?.toString()
-              : errorMessage;
+          const fieldErrorMessage = fieldStateError
+            ? (renderError?.(fieldStateError) ?? errorMessage ?? fieldStateError.message?.toString())
+            : undefined;
           const isError = !!fieldErrorMessage;
           const showHelperTextElement = !!(
             helperText

--- a/packages/rhf-mui-components/src/mui/autocomplete-object/index.tsx
+++ b/packages/rhf-mui-components/src/mui/autocomplete-object/index.tsx
@@ -320,10 +320,9 @@ const RHFAutocompleteObjectInner = forwardRef(function RHFAutocompleteObject<
         fieldState: { error: fieldStateError }
       }) => {
         const isDisabled = muiDisabled || rhfDisabled;
-        const fieldErrorMessage
-          = fieldStateError
-            ? renderError?.(fieldStateError) ?? fieldStateError.message?.toString()
-            : errorMessage;
+        const fieldErrorMessage = fieldStateError
+          ? (renderError?.(fieldStateError) ?? errorMessage ?? fieldStateError.message?.toString())
+          : undefined;
         const isError = !!fieldErrorMessage;
         const showHelperTextElement = !!(
           helperText

--- a/packages/rhf-mui-components/src/mui/autocomplete/index.tsx
+++ b/packages/rhf-mui-components/src/mui/autocomplete/index.tsx
@@ -383,10 +383,9 @@ const RHFAutocompleteInner = forwardRef(function RHFAutocomplete<
         fieldState: { error: fieldStateError }
       }) => {
         const isDisabled = muiDisabled || rhfDisabled;
-        const fieldErrorMessage
-          = fieldStateError
-            ? renderError?.(fieldStateError) ?? fieldStateError.message?.toString()
-            : errorMessage;
+        const fieldErrorMessage = fieldStateError
+          ? (renderError?.(fieldStateError) ?? errorMessage ?? fieldStateError.message?.toString())
+          : undefined;
         const isError = !!fieldErrorMessage;
         const showHelperTextElement = !!(
           helperText

--- a/packages/rhf-mui-components/src/mui/checkbox-group/index.tsx
+++ b/packages/rhf-mui-components/src/mui/checkbox-group/index.tsx
@@ -306,10 +306,9 @@ const RHFCheckboxGroup = <
         };
         const rhfValue = value ?? [];
         const isDisabled = muiDisabled || rhfDisabled;
-        const fieldErrorMessage
-          = fieldStateError
-            ? renderError?.(fieldStateError) ?? fieldStateError.message?.toString()
-            : errorMessage;
+        const fieldErrorMessage = fieldStateError
+          ? (renderError?.(fieldStateError) ?? errorMessage ?? fieldStateError.message?.toString())
+          : undefined;
         const isError = !!fieldErrorMessage;
         const showHelperTextElement = !!(
           helperText

--- a/packages/rhf-mui-components/src/mui/checkbox/index.tsx
+++ b/packages/rhf-mui-components/src/mui/checkbox/index.tsx
@@ -173,10 +173,9 @@ const RHFCheckboxInner = forwardRef(function RHFCheckbox<T extends FieldValues>(
         fieldState: { error: fieldStateError }
       }) => {
         const isDisabled = muiDisabled || rhfDisabled;
-        const fieldErrorMessage
-          = fieldStateError
-            ? renderError?.(fieldStateError) ?? fieldStateError.message?.toString()
-            : errorMessage;
+        const fieldErrorMessage = fieldStateError
+          ? (renderError?.(fieldStateError) ?? errorMessage ?? fieldStateError.message?.toString())
+          : undefined;
         const isError = !!fieldErrorMessage;
         const showHelperTextElement = !!(
           helperText

--- a/packages/rhf-mui-components/src/mui/country-select/index.tsx
+++ b/packages/rhf-mui-components/src/mui/country-select/index.tsx
@@ -364,10 +364,9 @@ ref: Ref<HTMLInputElement>) {
         fieldState: { error: fieldStateError }
       }) => {
         const isDisabled = muiDisabled || rhfDisabled;
-        const fieldErrorMessage
-          = fieldStateError
-            ? renderError?.(fieldStateError) ?? fieldStateError.message?.toString()
-            : errorMessage;
+        const fieldErrorMessage = fieldStateError
+          ? (renderError?.(fieldStateError) ?? errorMessage ?? fieldStateError.message?.toString())
+          : undefined;
         const isError = !!fieldErrorMessage;
         const showHelperTextElement = !!(
           helperText

--- a/packages/rhf-mui-components/src/mui/multi-autocomplete-object/index.tsx
+++ b/packages/rhf-mui-components/src/mui/multi-autocomplete-object/index.tsx
@@ -383,10 +383,9 @@ const RHFMultiAutocompleteObjectInner = forwardRef(function RHFMultiAutocomplete
         fieldState: { error: fieldStateError }
       }) => {
         const isDisabled = muiDisabled || rhfDisabled;
-        const fieldErrorMessage
-          = fieldStateError
-            ? renderError?.(fieldStateError) ?? fieldStateError.message?.toString()
-            : errorMessage;
+        const fieldErrorMessage = fieldStateError
+          ? (renderError?.(fieldStateError) ?? errorMessage ?? fieldStateError.message?.toString())
+          : undefined;
         const isError = !!fieldErrorMessage;
         const showHelperTextElement = !!(
           helperText

--- a/packages/rhf-mui-components/src/mui/multi-autocomplete/index.tsx
+++ b/packages/rhf-mui-components/src/mui/multi-autocomplete/index.tsx
@@ -393,10 +393,9 @@ const RHFMultiAutocompleteInner = forwardRef(function RHFMultiAutocomplete<
         fieldState: { error: fieldStateError }
       }) => {
         const isDisabled = muiDisabled || rhfDisabled;
-        const fieldErrorMessage
-          = fieldStateError
-            ? renderError?.(fieldStateError) ?? fieldStateError.message?.toString()
-            : errorMessage;
+        const fieldErrorMessage = fieldStateError
+          ? (renderError?.(fieldStateError) ?? errorMessage ?? fieldStateError.message?.toString())
+          : undefined;
         const isError = !!fieldErrorMessage;
         const showHelperTextElement = !!(
           helperText

--- a/packages/rhf-mui-components/src/mui/native-select/index.tsx
+++ b/packages/rhf-mui-components/src/mui/native-select/index.tsx
@@ -283,10 +283,9 @@ const RHFNativeSelectInner = forwardRef(function RHFNativeSelect<
         fieldState: { error: fieldStateError }
       }) => {
         const isDisabled = muiDisabled || rhfDisabled;
-        const fieldErrorMessage
-          = fieldStateError
-            ? renderError?.(fieldStateError) ?? fieldStateError.message?.toString()
-            : errorMessage;
+        const fieldErrorMessage = fieldStateError
+          ? (renderError?.(fieldStateError) ?? errorMessage ?? fieldStateError.message?.toString())
+          : undefined;
         const isError = !!fieldErrorMessage;
         const showHelperTextElement = !!(
           helperText

--- a/packages/rhf-mui-components/src/mui/number-input/index.tsx
+++ b/packages/rhf-mui-components/src/mui/number-input/index.tsx
@@ -417,10 +417,9 @@ const RHFNumberInputInner = forwardRef(function RHFNumberInput<T extends FieldVa
         fieldState: { error: fieldStateError }
       }) => {
         const isDisabled = muiDisabled || rhfDisabled;
-        const fieldErrorMessage
-          = fieldStateError
-            ? renderError?.(fieldStateError) ?? fieldStateError.message?.toString()
-            : errorMessage;
+        const fieldErrorMessage = fieldStateError
+          ? (renderError?.(fieldStateError) ?? errorMessage ?? fieldStateError.message?.toString())
+          : undefined;
         const isError = !!fieldErrorMessage;
         const showHelperTextElement = !!(
           helperText

--- a/packages/rhf-mui-components/src/mui/password-input/index.tsx
+++ b/packages/rhf-mui-components/src/mui/password-input/index.tsx
@@ -241,10 +241,9 @@ ref: Ref<HTMLInputElement>) {
         fieldState: { error: fieldStateError }
       }) => {
         const isDisabled = muiDisabled || rhfDisabled;
-        const fieldErrorMessage
-          = fieldStateError
-            ? renderError?.(fieldStateError) ?? fieldStateError.message?.toString()
-            : errorMessage;
+        const fieldErrorMessage = fieldStateError
+          ? (renderError?.(fieldStateError) ?? errorMessage ?? fieldStateError.message?.toString())
+          : undefined;
         const isError = !!fieldErrorMessage;
         const showHelperTextElement = !!(
           helperText

--- a/packages/rhf-mui-components/src/mui/radio-group/index.tsx
+++ b/packages/rhf-mui-components/src/mui/radio-group/index.tsx
@@ -278,10 +278,9 @@ const RHFRadioGroup = <
         fieldState: { error: fieldStateError }
       }) => {
         const isDisabled = muiDisabled || rhfDisabled;
-        const fieldErrorMessage
-          = fieldStateError
-            ? renderError?.(fieldStateError) ?? fieldStateError.message?.toString()
-            : errorMessage;
+        const fieldErrorMessage = fieldStateError
+          ? (renderError?.(fieldStateError) ?? errorMessage ?? fieldStateError.message?.toString())
+          : undefined;
         const isError = !!fieldErrorMessage;
         const showHelperTextElement = !!(
           helperText

--- a/packages/rhf-mui-components/src/mui/rating/index.tsx
+++ b/packages/rhf-mui-components/src/mui/rating/index.tsx
@@ -195,10 +195,9 @@ ref: Ref<HTMLSpanElement>) {
         fieldState: { error: fieldStateError }
       }) => {
         const isDisabled = muiDisabled || rhfDisabled;
-        const fieldErrorMessage
-          = fieldStateError
-            ? renderError?.(fieldStateError) ?? fieldStateError.message?.toString()
-            : errorMessage;
+        const fieldErrorMessage = fieldStateError
+          ? (renderError?.(fieldStateError) ?? errorMessage ?? fieldStateError.message?.toString())
+          : undefined;
         const isError = !!fieldErrorMessage;
         const showHelperTextElement = !!(
           helperText

--- a/packages/rhf-mui-components/src/mui/select/index.tsx
+++ b/packages/rhf-mui-components/src/mui/select/index.tsx
@@ -337,10 +337,9 @@ const RHFSelectInner = forwardRef(function RHFSelect<
           : labelId;
 
         const isDisabled = muiDisabled || rhfDisabled;
-        const fieldErrorMessage
-          = fieldStateError
-            ? renderError?.(fieldStateError) ?? fieldStateError.message?.toString()
-            : errorMessage;
+        const fieldErrorMessage = fieldStateError
+          ? (renderError?.(fieldStateError) ?? errorMessage ?? fieldStateError.message?.toString())
+          : undefined;
         const isError = !!fieldErrorMessage;
         const showHelperTextElement = !!(
           helperText

--- a/packages/rhf-mui-components/src/mui/slider/index.tsx
+++ b/packages/rhf-mui-components/src/mui/slider/index.tsx
@@ -200,10 +200,9 @@ ref: Ref<HTMLSpanElement>) {
         fieldState: { error: fieldStateError }
       }) => {
         const isDisabled = muiDisabled || rhfDisabled;
-        const fieldErrorMessage
-          = fieldStateError
-            ? renderError?.(fieldStateError) ?? fieldStateError.message?.toString()
-            : errorMessage;
+        const fieldErrorMessage = fieldStateError
+          ? (renderError?.(fieldStateError) ?? errorMessage ?? fieldStateError.message?.toString())
+          : undefined;
         const isError = !!fieldErrorMessage;
         const showHelperTextElement = !!(
           helperText

--- a/packages/rhf-mui-components/src/mui/switch/index.tsx
+++ b/packages/rhf-mui-components/src/mui/switch/index.tsx
@@ -172,10 +172,9 @@ const RHFSwitchInner = forwardRef(function RHFSwitch<T extends FieldValues>({
         fieldState: { error: fieldStateError }
       }) => {
         const isDisabled = muiDisabled || rhfDisabled;
-        const fieldErrorMessage
-          = fieldStateError
-            ? renderError?.(fieldStateError) ?? fieldStateError.message?.toString()
-            : errorMessage;
+        const fieldErrorMessage = fieldStateError
+          ? (renderError?.(fieldStateError) ?? errorMessage ?? fieldStateError.message?.toString())
+          : undefined;
         const isError = !!fieldErrorMessage;
         const showHelperTextElement = !!(
           helperText

--- a/packages/rhf-mui-components/src/mui/tags-input/index.tsx
+++ b/packages/rhf-mui-components/src/mui/tags-input/index.tsx
@@ -523,10 +523,9 @@ const RHFTagsInputInner = forwardRef(function RHFTagsInput<
         fieldState: { error: fieldStateError }
       }) => {
         const isDisabled = muiDisabled || rhfDisabled;
-        const fieldErrorMessage
-          = fieldStateError
-            ? renderError?.(fieldStateError) ?? fieldStateError.message?.toString()
-            : errorMessage;
+        const fieldErrorMessage = fieldStateError
+          ? (renderError?.(fieldStateError) ?? errorMessage ?? fieldStateError.message?.toString())
+          : undefined;
         const isError = !!fieldErrorMessage;
         const showHelperTextElement = !!(
           helperText

--- a/packages/rhf-mui-components/src/mui/textfield/index.tsx
+++ b/packages/rhf-mui-components/src/mui/textfield/index.tsx
@@ -179,10 +179,9 @@ const RHFTextFieldInner = forwardRef(function RHFTextField<T extends FieldValues
         fieldState: { error: fieldStateError }
       }) => {
         const isDisabled = muiDisabled || rhfDisabled;
-        const fieldErrorMessage
-          = fieldStateError
-            ? renderError?.(fieldStateError) ?? fieldStateError.message?.toString()
-            : errorMessage;
+        const fieldErrorMessage = fieldStateError
+          ? (renderError?.(fieldStateError) ?? errorMessage ?? fieldStateError.message?.toString())
+          : undefined;
         const isError = !!fieldErrorMessage;
         const showHelperTextElement = !!(
           helperText


### PR DESCRIPTION
### 🐞 Bug Fixes
- Corrected field error resolution to prefer `renderError`, then legacy `errorMessage`, then RHF-derived error messages.