### PR TITLE
v3.4.3 - Add missing import for RHFMultiAutocompleteObject, update jsdoc for props

### DIFF
--- a/apps/rhf-mui-demo/package.json
+++ b/apps/rhf-mui-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-demo",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "private": true,
   "author": "Nishant Kohli",
   "scripts": {

--- a/apps/rhf-mui-demo/src/forms/inputs-with-register-options/index.tsx
+++ b/apps/rhf-mui-demo/src/forms/inputs-with-register-options/index.tsx
@@ -136,7 +136,6 @@ const InputsWithRegisterForm = () => {
             <RHFTextField
               fieldName="email"
               control={control}
-              errorMessage={errors?.email?.message}
               registerOptions={{
                 pattern: {
                   value: /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/,
@@ -144,7 +143,9 @@ const InputsWithRegisterForm = () => {
                 }
               }}
               variant="standard"
+              type="email"
               showLabelAboveFormField
+              errorMessage={errors?.email?.message}
             />
           </Grid>
           <Grid size={{ xs: 12, md: 6 }}>

--- a/apps/rhf-mui-docs/package.json
+++ b/apps/rhf-mui-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-docs",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/changelog/v3.md
+++ b/changelog/v3.md
@@ -1,5 +1,18 @@
 # Changelog - v3
 
+## [3.4.3](https://github.com/nishkohli96/rhf-mui-components/tree/v3.4.3)
+
+**Released - 10 July, 2026**
+
+### ✨ Enhancements
+- Improved JSDoc for the `options` prop in `RHFAutocomplete`, `RHFAutocompleteObject`, `RHFMultiAutocomplete`, and `RHFMultiAutocompleteObject`.
+- Refined the JSDoc wording for the `showLabelAboveFormField` prop across all component.
+
+### 🐞 Bug Fixes
+- Added missing exports for `RHFMultiAutocompleteObject` and `RHFMultiAutocompleteObjectProps` to the `mui` index module.
+- Removed the `id` prop from `RHFRichTextEditor`, as the internally generated field id was already being assigned to the `CKEditor` instance.
+
+
 ## [3.4.2](https://github.com/nishkohli96/rhf-mui-components/tree/v3.4.2)
 
 **Released - 7 July, 2026**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-components-root",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "A suite of 20+ production-ready react-hook-form components built with material-ui. Fully typed, tree-shakable, and optimized for enterprise-grade forms.",
   "author": "Nishant Kohli",
   "private": true,

--- a/packages/rhf-mui-components/package.json
+++ b/packages/rhf-mui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-components",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "description": "A suite of 20+ production-ready react-hook-form components built with material-ui. Fully typed, tree-shakable, and optimized for enterprise-grade forms.",
   "author": "Nishant Kohli",
   "homepage": "https://rhf-mui-components.vercel.app/",

--- a/packages/rhf-mui-components/src/index.ts
+++ b/packages/rhf-mui-components/src/index.ts
@@ -1,4 +1,4 @@
 export * from './config';
 export * from './form-helpers';
 export * from './mui';
-export * from './types';
+export type * from './types';

--- a/packages/rhf-mui-components/src/misc/color-picker/index.tsx
+++ b/packages/rhf-mui-components/src/misc/color-picker/index.tsx
@@ -46,7 +46,9 @@ export type RHFColorPickerProps<T extends FieldValues> = {
    * Validation rules passed to React Hook Form for this field.
    */
   registerOptions?: RegisterOptions<T, Path<T>>;
-  /** Initial color value used by the color picker. */
+  /**
+   * Initial color value used by the color picker.
+   */
   value?: string;
   /**
    * Color format stored in the React Hook Form field.
@@ -85,7 +87,6 @@ export type RHFColorPickerProps<T extends FieldValues> = {
    * those inputs.
    */
   hideInput?: (keyof IColor)[] | boolean;
-
   /**
    * Callback fired after the picker changes and the formatted color is stored in the field.
    * @param color - Full color object from `react-color-palette`.
@@ -100,7 +101,7 @@ export type RHFColorPickerProps<T extends FieldValues> = {
    */
   label?: ReactNode;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component instead of within the field layout.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/misc/phone-input/index.tsx
+++ b/packages/rhf-mui-components/src/misc/phone-input/index.tsx
@@ -94,7 +94,7 @@ export type RHFPhoneInputProps<T extends FieldValues> = {
    */
   onValueChange?: (phoneData: PhoneInputChangeReturnValue) => void;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component instead of within the field layout.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/misc/rich-text-editor/index.tsx
+++ b/packages/rhf-mui-components/src/misc/rich-text-editor/index.tsx
@@ -52,12 +52,6 @@ export type RHFRichTextEditorProps<T extends FieldValues> = {
    */
   required?: boolean;
   /**
-   * HTML id applied to the CKEditor instance.
-   *
-   * Defaults to the generated field id.
-   */
-  id?: string;
-  /**
    * CKEditor configuration passed to `ClassicEditor`.
    *
    * Defaults to this package's `DefaultEditorConfig`.
@@ -93,7 +87,7 @@ export type RHFRichTextEditorProps<T extends FieldValues> = {
    */
   label?: ReactNode;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component instead of within the field layout.
    */
   showLabelAboveFormField?: boolean;
   /**
@@ -129,7 +123,6 @@ const RHFRichTextEditor = <T extends FieldValues>({
   control,
   registerOptions,
   required,
-  id,
   editorConfig,
   onReady,
   onFocus,
@@ -191,7 +184,7 @@ const RHFRichTextEditor = <T extends FieldValues>({
               }}
             />
             <CKEditor
-              id={id ?? fieldId}
+              id={fieldId}
               editor={ClassicEditor}
               config={editorConfig ?? DefaultEditorConfig}
               data={rhfValue}

--- a/packages/rhf-mui-components/src/mui-pickers/date-time/index.tsx
+++ b/packages/rhf-mui-components/src/mui-pickers/date-time/index.tsx
@@ -66,7 +66,7 @@ export type RHFDateTimePickerProps<T extends FieldValues> = {
     context: PickerChangeHandlerContext<DateTimeValidationError>
   ) => void;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component instead of within the field layout.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui-pickers/date/index.tsx
+++ b/packages/rhf-mui-components/src/mui-pickers/date/index.tsx
@@ -66,7 +66,7 @@ export type RHFDatePickerProps<T extends FieldValues> = {
     context: PickerChangeHandlerContext<DateValidationError>
   ) => void;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component instead of within the field layout.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui-pickers/time/index.tsx
+++ b/packages/rhf-mui-components/src/mui-pickers/time/index.tsx
@@ -66,7 +66,7 @@ export type RHFTimePickerProps<T extends FieldValues> = {
     context: PickerChangeHandlerContext<TimeValidationError>
   ) => void;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component instead of within the field layout.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui/autocomplete-object/index.tsx
+++ b/packages/rhf-mui-components/src/mui/autocomplete-object/index.tsx
@@ -93,7 +93,7 @@ export type RHFAutocompleteObjectProps<
    */
   registerOptions?: RegisterOptions<T, Path<T>>;
   /**
-   * Options rendered by the field.
+   * A list of options that will be shown in the Autocomplete.
    */
   options: Option[];
   /**
@@ -131,7 +131,7 @@ export type RHFAutocompleteObjectProps<
    */
   label?: ReactNode;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component instead of within the field layout.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui/autocomplete/index.tsx
+++ b/packages/rhf-mui-components/src/mui/autocomplete/index.tsx
@@ -98,7 +98,7 @@ export type RHFAutocompleteProps<
    */
   registerOptions?: RegisterOptions<T, Path<T>>;
   /**
-   * Options rendered by the field.
+   * A list of options that will be shown in the Autocomplete.
    */
   options: Option[];
   /**
@@ -136,7 +136,7 @@ export type RHFAutocompleteProps<
    */
   label?: ReactNode;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component instead of within the field layout.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui/checkbox-group/index.tsx
+++ b/packages/rhf-mui-components/src/mui/checkbox-group/index.tsx
@@ -89,8 +89,12 @@ export type RHFCheckboxGroupProps<
    * Label content shown for the field. Defaults to a label generated from `fieldName`.
    */
   label?: ReactNode;
-  /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+  /*
+   * Whether the field label renders above the checkbox group. The group has no
+   * built-in inline label, so this defaults to `true`; pass `false` to hide the
+   * visible label (the accessible name is still applied).
+   *
+   * @default true
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui/country-select/index.tsx
+++ b/packages/rhf-mui-components/src/mui/country-select/index.tsx
@@ -143,7 +143,7 @@ export type RHFCountrySelectProps<
    */
   label?: ReactNode;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component instead of within the field layout.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui/file-uploader/index.tsx
+++ b/packages/rhf-mui-components/src/mui/file-uploader/index.tsx
@@ -131,7 +131,7 @@ export type RHFFileUploaderProps<T extends FieldValues> = {
    */
   label?: ReactNode;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui/index.ts
+++ b/packages/rhf-mui-components/src/mui/index.ts
@@ -15,6 +15,9 @@ import RHFFileUploader, {
 import RHFMultiAutocomplete, {
   type RHFMultiAutocompleteProps,
 } from './multi-autocomplete';
+import RHFMultiAutocompleteObject, {
+  type RHFMultiAutocompleteObjectProps,
+} from './multi-autocomplete-object';
 import RHFNativeSelect, { type RHFNativeSelectProps } from './native-select';
 import RHFNumberInput, { type RHFNumberInputProps } from './number-input';
 import RHFPasswordInput, { type RHFPasswordInputProps } from './password-input';
@@ -35,6 +38,7 @@ export {
   RHFCountrySelect,
   RHFFileUploader,
   RHFMultiAutocomplete,
+  RHFMultiAutocompleteObject,
   RHFNativeSelect,
   RHFNumberInput,
   RHFPasswordInput,
@@ -58,6 +62,7 @@ export type {
   RHFFileUploaderProps,
   FileUploadError,
   RHFMultiAutocompleteProps,
+  RHFMultiAutocompleteObjectProps,
   RHFNativeSelectProps,
   RHFNumberInputProps,
   RHFPasswordInputProps,

--- a/packages/rhf-mui-components/src/mui/multi-autocomplete-object/index.tsx
+++ b/packages/rhf-mui-components/src/mui/multi-autocomplete-object/index.tsx
@@ -95,7 +95,7 @@ export type RHFMultiAutocompleteObjectProps<
    */
   registerOptions?: RegisterOptions<T, Path<T>>;
   /**
-   * Options rendered by the field.
+   * An array of options displayed in the autocomplete dropdown for multiple selection.
    */
   options: Option[];
   /**
@@ -130,7 +130,7 @@ export type RHFMultiAutocompleteObjectProps<
    */
   label?: ReactNode;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component instead of within the field layout.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui/multi-autocomplete/index.tsx
+++ b/packages/rhf-mui-components/src/mui/multi-autocomplete/index.tsx
@@ -95,7 +95,7 @@ export type RHFMultiAutocompleteProps<
    */
   registerOptions?: RegisterOptions<T, Path<T>>;
   /**
-   * Options rendered by the field.
+   * An array of options displayed in the autocomplete dropdown for multiple selection.
    */
   options: Option[];
   /**
@@ -133,7 +133,7 @@ export type RHFMultiAutocompleteProps<
    */
   label?: ReactNode;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component instead of within the field layout.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui/native-select/index.tsx
+++ b/packages/rhf-mui-components/src/mui/native-select/index.tsx
@@ -84,7 +84,7 @@ export type RHFNativeSelectProps<
    */
   defaultOptionText?: string;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When true, renders the field label above the component.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui/number-input/index.tsx
+++ b/packages/rhf-mui-components/src/mui/number-input/index.tsx
@@ -55,7 +55,7 @@ export type RHFNumberInputProps<T extends FieldValues> = {
     event: ChangeEvent<HTMLInputElement>
   ) => void;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component instead of within the field layout.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui/password-input/index.tsx
+++ b/packages/rhf-mui-components/src/mui/password-input/index.tsx
@@ -69,7 +69,7 @@ export type RHFPasswordInputProps<T extends FieldValues> = {
     event: ChangeEvent<HTMLInputElement>
   ) => void;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component instead of within the field layout.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui/radio-group/index.tsx
+++ b/packages/rhf-mui-components/src/mui/radio-group/index.tsx
@@ -88,7 +88,7 @@ export type RHFRadioGroupProps<
    */
   label?: ReactNode;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui/rating/index.tsx
+++ b/packages/rhf-mui-components/src/mui/rating/index.tsx
@@ -59,7 +59,7 @@ export type RHFRatingProps<T extends FieldValues> = {
    */
   label?: ReactNode;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui/select/index.tsx
+++ b/packages/rhf-mui-components/src/mui/select/index.tsx
@@ -111,7 +111,7 @@ export type RHFSelectProps<
     child: ReactNode
   ) => void;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component instead of within the field layout.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui/slider/index.tsx
+++ b/packages/rhf-mui-components/src/mui/slider/index.tsx
@@ -58,7 +58,7 @@ export type RHFSliderProps<T extends FieldValues> = {
    */
   label?: ReactNode;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui/tags-input/index.tsx
+++ b/packages/rhf-mui-components/src/mui/tags-input/index.tsx
@@ -71,7 +71,7 @@ export type RHFTagsInputProps<T extends FieldValues> = {
    */
   onValueChange?: (tags: string[]) => void;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component instead of within the field layout.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui/textfield/index.tsx
+++ b/packages/rhf-mui-components/src/mui/textfield/index.tsx
@@ -49,7 +49,7 @@ export type RHFTextFieldProps<T extends FieldValues> = {
     event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   ) => void;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component instead of within the field layout.
    */
   showLabelAboveFormField?: boolean;
   /**


### PR DESCRIPTION
### ✨ Enhancements
- Improved JSDoc for the `options` prop in `RHFAutocomplete`, `RHFAutocompleteObject`, `RHFMultiAutocomplete`, and `RHFMultiAutocompleteObject`.
- Refined the JSDoc wording for the `showLabelAboveFormField` prop across all component.

### 🐞 Bug Fixes
- Added missing exports for `RHFMultiAutocompleteObject` and `RHFMultiAutocompleteObjectProps` to the `mui` index module.
- Removed the `id` prop from `RHFRichTextEditor`, as the internally generated field id was already being assigned to the `CKEditor` instance.