### PR TITLE
v4.1.3 - Add missing exports for RHFMultiAutocompleteObject;  refined JSDoc wording for showLabelAboveFormField prop

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,6 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Build Components Package
         run: pnpm -F @nish1896/rhf-mui-components run lib:build
-      # - name: Publish package on npm
-      #   run: npm publish --tag latest-v4
-      #   working-directory: packages/rhf-mui-components/dist
+      - name: Publish package on npm
+        run: npm publish --tag latest-v4
+        working-directory: packages/rhf-mui-components/dist

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,6 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Build Components Package
         run: pnpm -F @nish1896/rhf-mui-components run lib:build
-      - name: Publish package on npm
-        run: npm publish --tag latest-v4
-        working-directory: packages/rhf-mui-components/dist
+      # - name: Publish package on npm
+      #   run: npm publish --tag latest-v4
+      #   working-directory: packages/rhf-mui-components/dist

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,6 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Build Components Package
         run: pnpm -F @nish1896/rhf-mui-components run lib:build
-      # - name: Publish package on npm
-      #   run: npm publish --tag latest-v4
-      #   working-directory: packages/rhf-mui-components/dist
+      - name: Publish package on npm
+        run: npm publish --tag latest
+        working-directory: packages/rhf-mui-components/dist

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,5 +32,5 @@ jobs:
       - name: Build Components Package
         run: pnpm -F @nish1896/rhf-mui-components run lib:build
       - name: Publish package on npm
-        run: npm publish --tag latest
+        run: npm publish --tag latest-v4
         working-directory: packages/rhf-mui-components/dist

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ yarn-debug.log*
 yarn-error.log*
 
 publish-pkg.sh
+
+# AI Agents
+.claude

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ coverage
 
 # misc
 .DS_Store
+.pnpm-store
 .env
 .env.*
 *.log

--- a/apps/rhf-mui-demo/next-env.d.ts
+++ b/apps/rhf-mui-demo/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/rhf-mui-demo/package.json
+++ b/apps/rhf-mui-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-demo",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "private": true,
   "author": "Nishant Kohli",
   "scripts": {

--- a/apps/rhf-mui-demo/src/forms/inputs-with-register-options/index.tsx
+++ b/apps/rhf-mui-demo/src/forms/inputs-with-register-options/index.tsx
@@ -159,6 +159,7 @@ const InputsWithRegisterForm = () => {
                   message: 'Enter a valid email address'
                 }
               }}
+              type="email"
               customIds={{
                 field: 'userEmail',
                 label: 'userEmail-label',

--- a/apps/rhf-mui-docs/package.json
+++ b/apps/rhf-mui-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-docs",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/apps/rhf-mui-docs/src/constants/props.ts
+++ b/apps/rhf-mui-docs/src/constants/props.ts
@@ -606,7 +606,7 @@ const PropsDescription: Record<
   id_Rte: {
     name: 'id',
     description:
-      'The context ID. When this property changes, the component restarts the context with its editor and reinitializes it based on the current configuration.',
+      'The context ID. When this property changes, the component restarts the context with its editor and reinitializes it based on the current configuration. Removed in `v4.1.3` as the internally generated field id was already being assigned to the `CKEditor` instance.',
     type: 'string'
   },
   onReady_Rte: {

--- a/changelog/v3.md
+++ b/changelog/v3.md
@@ -1,5 +1,18 @@
 # Changelog - v3
 
+## [3.4.3](https://github.com/nishkohli96/rhf-mui-components/tree/v3.4.3)
+
+**Released - 10 July, 2026**
+
+### ✨ Enhancements
+- Improved JSDoc for the `options` prop in `RHFAutocomplete`, `RHFAutocompleteObject`, `RHFMultiAutocomplete`, and `RHFMultiAutocompleteObject`.
+- Refined the JSDoc wording for the `showLabelAboveFormField` prop across all component.
+
+### 🐞 Bug Fixes
+- Added missing exports for `RHFMultiAutocompleteObject` and `RHFMultiAutocompleteObjectProps` to the `mui` index module.
+- Removed the `id` prop from `RHFRichTextEditor`, as the internally generated field id was already being assigned to the `CKEditor` instance.
+
+
 ## [3.4.2](https://github.com/nishkohli96/rhf-mui-components/tree/v3.4.2)
 
 **Released - 7 July, 2026**
@@ -25,7 +38,6 @@
 
 ### 🐞 Bug Fixes
 - Fixed MUI error styling being incorrectly applied to helper text when `hideErrorMessage` is enabled.
-
 
 ## [3.4.0](https://github.com/nishkohli96/rhf-mui-components/tree/v3.4.0)
 
@@ -150,16 +162,12 @@ This update includes the following fixes in **v4**:
 - **validateArray**: Skipped validation for option based components in `production` environment to avoid expensive runtime checks
 - Updated `tsdown` from `0.20.3` to `0.21.4`
 
-
 ## [3.2.3](https://github.com/nishkohli96/rhf-mui-components/tree/v3.2.3)
 
 **Released - 10 March, 2026**
 
 ### Bug Fixes 🐞
 - Improve `fieldNameToLabel` to support `fieldArray` field names (e.g., `bank.0.accountNumber`).
-
-**Deprecated all versions below v3.**
-
 
 ## [3.2.2](https://github.com/nishkohli96/rhf-mui-components/tree/v3.2.2)
 
@@ -170,7 +178,6 @@ This update includes the following fixes in **v4**:
 - Add `use client` directive for all components
 - **ESM** only exports in `package.json`
 - Upgrade Github `actions/checkout` & `actions/setup-node` from `v4` to `v6` and node-version from `20` to `24`.
-
 
 ## [3.2.1](https://github.com/nishkohli96/rhf-mui-components/tree/v3.2.1)
 
@@ -200,7 +207,6 @@ This update includes the following fixes in **v4**:
 |[@nish1896/eslint-flat-config](https://www.npmjs.com/package/@nish1896/eslint-config) | `2.0.4` | `3.1.1` |
 | [zod](https://www.npmjs.com/package/zod) | `3.23.8` | `4.3.6` |
 
-
 ## [3.2.0](https://github.com/nishkohli96/rhf-mui-components/tree/v3.2.0)
 
 **Released - 23 February, 2026**
@@ -225,7 +231,6 @@ This update includes the following fixes in **v4**:
 - `RHFSelect`: Make the `placeholder` text blurred when no option is selected.
 - `RHFMultiAutocomplete`: Improved selection logic and fixed checkbox sync issues with `defaultValues`.
 
-
 ## [3.1.4](https://github.com/nishkohli96/rhf-mui-components/tree/v3.1.4)
 
 **Released - 25 December, 2025**
@@ -234,14 +239,12 @@ This update includes the following fixes in **v4**:
 - Enable `inputProps` and `slotProps` for `RHFAutocomplete` and `RHFMultiAutocomplete`.
 - Fixed an issue where the loading spinner was not displayed in Autocomplete components when the `loading` prop was set to *true*.
 
-
 ## [3.1.3](https://github.com/nishkohli96/rhf-mui-components/tree/v3.1.3)
 
 **Released - 17 December, 2025**
 
 ### RHFAutocomplete Fixes
 - The `renderOption` prop is now supported, allowing developers to fully customize how options are rendered. A relevant example with code snippet has also been provided.
-
 
 ## [3.1.2](https://github.com/nishkohli96/rhf-mui-components/tree/v3.1.2)
 
@@ -251,13 +254,11 @@ This update includes the following fixes in **v4**:
 - Correct `renderValue` logic which was rendering value(s) instead of label in the **Select** field.
 - Deprecation removed for `showDefaultOption` & `defaultOptionText` props
 
-
 ## [3.1.1](https://github.com/nishkohli96/rhf-mui-components/tree/v3.1.1)
 
 **Released - 10 December, 2025**
 
 - Update **README.md** of the package
-
 
 ## [3.1.0](https://github.com/nishkohli96/rhf-mui-components/tree/v3.1.0)
 
@@ -267,21 +268,18 @@ This update includes the following fixes in **v4**:
 - Add `placeholder` prop
 - Mark `showDefaultOption` & `defaultOptionText` props as *deprecated*.
 
-
 ## [3.0.2](https://github.com/nishkohli96/rhf-mui-components/tree/v3.0.2)
 
 **Released - 18 August, 2025**
 
 - **RHFMultiAutoComplete**: Hide `Select All` option when length of options array is either 0 or 1. Remove placeholder when atleast one option is selected.
-- Add `bump-version.sh` script to increment the version of all packages to a specific version.
-
+- Add `bump-version.sh` script to increment version of all packages to a specific version.
 
 ## [3.0.1](https://github.com/nishkohli96/rhf-mui-components/tree/v3.0.1)
 
 **Released - 2 July, 2025**
 
 - Handle `onBlur` for all fields except for `RHFFileUploader`, `RHFColorPicker`. The blur event for date and time pickers can be passed via `slotProps.textField`.
-
 
 ## [3.0.0](https://github.com/nishkohli96/rhf-mui-components/tree/v3.0.0)
 

--- a/changelog/v4.md
+++ b/changelog/v4.md
@@ -4,9 +4,13 @@
 
 **Released — 9 July, 2026**
 
+### ✨ Enhancements
+- Improved JSDoc for the `options` prop in `RHFAutocomplete`, `RHFAutocompleteObject`, `RHFMultiAutocomplete`, and `RHFMultiAutocompleteObject`.
+- Refined the JSDoc wording for the `showLabelAboveFormField` prop across all component.
+
 ### 🐞 Bug Fixes
 - Added missing exports for `RHFMultiAutocompleteObject` and `RHFMultiAutocompleteObjectProps` to the `mui` index module.
-- Fixed the JSDoc for the `showLabelAboveFormField` prop in `RHFCheckboxGroup`.
+- Removed the `id` prop from `RHFRichTextEditor`, as the internally generated field id was already being assigned to the `CKEditor` instance.
 
 
 ## [4.1.2](https://github.com/nishkohli96/rhf-mui-components/tree/v4.1.2)

--- a/changelog/v4.md
+++ b/changelog/v4.md
@@ -2,7 +2,7 @@
 
 ## [4.1.3](https://github.com/nishkohli96/rhf-mui-components/tree/v4.1.3)
 
-**Released — 9 July, 2026**
+**Released — 10 July, 2026**
 
 ### ✨ Enhancements
 - Improved JSDoc for the `options` prop in `RHFAutocomplete`, `RHFAutocompleteObject`, `RHFMultiAutocomplete`, and `RHFMultiAutocompleteObject`.
@@ -10,6 +10,7 @@
 
 ### 🐞 Bug Fixes
 - Added missing exports for `RHFMultiAutocompleteObject` and `RHFMultiAutocompleteObjectProps` to the `mui` index module.
+- Fix Autocomplete components to fully respect `hideLabel` by preventing inline MUI TextField labels from rendering when labels are hidden.
 - Removed the `id` prop from `RHFRichTextEditor`, as the internally generated field id was already being assigned to the `CKEditor` instance.
 
 

--- a/changelog/v4.md
+++ b/changelog/v4.md
@@ -1,5 +1,14 @@
 # Changelog - v4
 
+## [4.1.3](https://github.com/nishkohli96/rhf-mui-components/tree/v4.1.3)
+
+**Released — 9 July, 2026**
+
+### 🐞 Bug Fixes
+- Added missing exports for `RHFMultiAutocompleteObject` and `RHFMultiAutocompleteObjectProps` to the `mui` index module.
+- Fixed the JSDoc for the `showLabelAboveFormField` prop in `RHFCheckboxGroup`.
+
+
 ## [4.1.2](https://github.com/nishkohli96/rhf-mui-components/tree/v4.1.2)
 
 **Released — 8 July, 2026**

--- a/changelog/v4.md
+++ b/changelog/v4.md
@@ -1,6 +1,6 @@
 # Changelog - v4
 
-## [4.1.1](https://github.com/nishkohli96/rhf-mui-components/tree/v4.1.1)
+## [4.1.2](https://github.com/nishkohli96/rhf-mui-components/tree/v4.1.2)
 
 **Released — 8 July, 2026**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-components-root",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "A suite of 25+ production-ready react-hook-form components built with material-ui. Fully typed, tree-shakable, and optimized for enterprise-grade forms.",
   "author": "Nishant Kohli",
   "private": true,

--- a/packages/rhf-mui-components/package.json
+++ b/packages/rhf-mui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-components",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "A suite of 25+ production-ready react-hook-form components built with material-ui. Fully typed, tree-shakable, and optimized for enterprise-grade forms.",
   "author": "Nishant Kohli",
   "homepage": "https://rhf-mui-components.vercel.app/",

--- a/packages/rhf-mui-components/src/misc/color-picker/index.tsx
+++ b/packages/rhf-mui-components/src/misc/color-picker/index.tsx
@@ -125,7 +125,7 @@ export type RHFColorPickerProps<T extends FieldValues> = {
    */
   label?: ReactNode;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/misc/color-picker/index.tsx
+++ b/packages/rhf-mui-components/src/misc/color-picker/index.tsx
@@ -125,7 +125,8 @@ export type RHFColorPickerProps<T extends FieldValues> = {
    */
   label?: ReactNode;
   /**
-   * When `true`, renders the label above the component.
+   * Renders the label above the component.
+   * @default true
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/misc/phone-input/index.tsx
+++ b/packages/rhf-mui-components/src/misc/phone-input/index.tsx
@@ -208,7 +208,7 @@ export type RHFPhoneInputProps<T extends FieldValues> = {
    */
   searchCountryProps?: SearchCountryProps;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component instead of within the field layout.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/misc/rich-text-editor/index.tsx
+++ b/packages/rhf-mui-components/src/misc/rich-text-editor/index.tsx
@@ -77,12 +77,6 @@ export type RHFRichTextEditorProps<T extends FieldValues> = {
    */
   required?: boolean;
   /**
-   * HTML id applied to the CKEditor instance.
-   *
-   * Defaults to the generated field id.
-   */
-  id?: string;
-  /**
    * CKEditor configuration passed to `ClassicEditor`.
    *
    * Defaults to this package's `DefaultEditorConfig`.
@@ -143,7 +137,7 @@ export type RHFRichTextEditorProps<T extends FieldValues> = {
    */
   label?: ReactNode;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component.
    */
   showLabelAboveFormField?: boolean;
   /**
@@ -199,7 +193,6 @@ const RHFRichTextEditorInner = forwardRef(function RHFRichTextEditorInner<
     control,
     registerOptions,
     required,
-    id,
     editorConfig,
     onReady,
     onFocus,
@@ -280,7 +273,7 @@ const RHFRichTextEditorInner = forwardRef(function RHFRichTextEditorInner<
               />
             )}
             <CKEditor
-              id={id ?? fieldId}
+              id={fieldId}
               editor={ClassicEditor}
               config={editorConfig ?? DefaultEditorConfig}
               data={rhfValue ?? ''}

--- a/packages/rhf-mui-components/src/misc/rich-text-editor/index.tsx
+++ b/packages/rhf-mui-components/src/misc/rich-text-editor/index.tsx
@@ -137,7 +137,8 @@ export type RHFRichTextEditorProps<T extends FieldValues> = {
    */
   label?: ReactNode;
   /**
-   * When `true`, renders the label above the component.
+   * Renders the label above the component.
+   * @default true
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui-pickers/date-time/RHFDateTimePicker.tsx
+++ b/packages/rhf-mui-components/src/mui-pickers/date-time/RHFDateTimePicker.tsx
@@ -102,7 +102,7 @@ export type RHFDateTimePickerProps<T extends FieldValues> = {
     context
   }: PickerOnValueChangeProps<DateTimeValidationError>) => void;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component instead of within the field layout.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui-pickers/date-time/RHFDesktopDateTimePicker.tsx
+++ b/packages/rhf-mui-components/src/mui-pickers/date-time/RHFDesktopDateTimePicker.tsx
@@ -102,7 +102,7 @@ export type RHFDesktopDateTimePickerProps<T extends FieldValues> = {
     context
   }: PickerOnValueChangeProps<DateTimeValidationError>) => void;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component instead of within the field layout.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui-pickers/date-time/RHFMobileDateTimePicker.tsx
+++ b/packages/rhf-mui-components/src/mui-pickers/date-time/RHFMobileDateTimePicker.tsx
@@ -102,7 +102,7 @@ export type RHFMobileDateTimePickerProps<T extends FieldValues> = {
     context
   }: PickerOnValueChangeProps<DateTimeValidationError>) => void;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component instead of within the field layout.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui-pickers/date-time/RHFStaticDateTimePicker.tsx
+++ b/packages/rhf-mui-components/src/mui-pickers/date-time/RHFStaticDateTimePicker.tsx
@@ -105,7 +105,7 @@ export type RHFStaticDateTimePickerProps<T extends FieldValues> = {
    */
   label?: ReactNode;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component instead of within the field layout.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui-pickers/date/RHFDatePicker.tsx
+++ b/packages/rhf-mui-components/src/mui-pickers/date/RHFDatePicker.tsx
@@ -106,7 +106,7 @@ export type RHFDatePickerProps<T extends FieldValues> = {
     context
   }: PickerOnValueChangeProps<DateValidationError>) => void;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component instead of within the field layout.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui-pickers/date/RHFDesktopDatePicker.tsx
+++ b/packages/rhf-mui-components/src/mui-pickers/date/RHFDesktopDatePicker.tsx
@@ -102,7 +102,7 @@ export type RHFDesktopDatePickerProps<T extends FieldValues> = {
     context
   }: PickerOnValueChangeProps<DateValidationError>) => void;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component instead of within the field layout.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui-pickers/date/RHFMobileDatePicker.tsx
+++ b/packages/rhf-mui-components/src/mui-pickers/date/RHFMobileDatePicker.tsx
@@ -102,7 +102,7 @@ export type RHFMobileDatePickerProps<T extends FieldValues> = {
     context
   }: PickerOnValueChangeProps<DateValidationError>) => void;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component instead of within the field layout.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui-pickers/date/RHFStaticDatePicker.tsx
+++ b/packages/rhf-mui-components/src/mui-pickers/date/RHFStaticDatePicker.tsx
@@ -105,7 +105,7 @@ export type RHFStaticDatePickerProps<T extends FieldValues> = {
    */
   label?: ReactNode;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component instead of within the field layout.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui-pickers/time/RHFDesktopTimePicker.tsx
+++ b/packages/rhf-mui-components/src/mui-pickers/time/RHFDesktopTimePicker.tsx
@@ -102,7 +102,7 @@ export type RHFDesktopTimePickerProps<T extends FieldValues> = {
     context
   }: PickerOnValueChangeProps<TimeValidationError>) => void;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component instead of within the field layout.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui-pickers/time/RHFMobileTimePicker.tsx
+++ b/packages/rhf-mui-components/src/mui-pickers/time/RHFMobileTimePicker.tsx
@@ -102,7 +102,7 @@ export type RHFMobileTimePickerProps<T extends FieldValues> = {
     context
   }: PickerOnValueChangeProps<TimeValidationError>) => void;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component instead of within the field layout.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui-pickers/time/RHFStaticTimePicker.tsx
+++ b/packages/rhf-mui-components/src/mui-pickers/time/RHFStaticTimePicker.tsx
@@ -105,7 +105,7 @@ export type RHFStaticTimePickerProps<T extends FieldValues> = {
    */
   label?: ReactNode;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component instead of within the field layout.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui-pickers/time/RHFTimePicker.tsx
+++ b/packages/rhf-mui-components/src/mui-pickers/time/RHFTimePicker.tsx
@@ -102,7 +102,7 @@ export type RHFTimePickerProps<T extends FieldValues> = {
     context
   }: PickerOnValueChangeProps<TimeValidationError>) => void;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component instead of within the field layout.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui/autocomplete-object/index.tsx
+++ b/packages/rhf-mui-components/src/mui/autocomplete-object/index.tsx
@@ -103,7 +103,7 @@ export type RHFAutocompleteObjectProps<
    */
   registerOptions?: RegisterOptions<T, Path<T>>;
   /**
-   * Options rendered by the field.
+   * A list of options that will be shown in the Autocomplete.
    */
   options: Option[];
   /**
@@ -168,7 +168,7 @@ export type RHFAutocompleteObjectProps<
    */
   label?: ReactNode;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component instead of within the field layout.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui/autocomplete-object/index.tsx
+++ b/packages/rhf-mui-components/src/mui/autocomplete-object/index.tsx
@@ -425,7 +425,7 @@ const RHFAutocompleteObjectInner = forwardRef(function RHFAutocompleteObject<
                     {...otherTextFieldProps}
                     {...otherInputParams}
                     label={
-                      !isLabelAboveFormField
+                      !hideLabel && !isLabelAboveFormField
                         ? (
                           <FormLabelText label={fieldLabel} required={required} />
                         )

--- a/packages/rhf-mui-components/src/mui/autocomplete/index.tsx
+++ b/packages/rhf-mui-components/src/mui/autocomplete/index.tsx
@@ -571,7 +571,7 @@ const RHFAutocompleteInner = forwardRef(function RHFAutocomplete<
                     {...otherTextFieldProps}
                     {...otherInputParams}
                     label={
-                      !isLabelAboveFormField
+                      !hideLabel && !isLabelAboveFormField
                         ? (
                           <FormLabelText
                             label={fieldLabel}

--- a/packages/rhf-mui-components/src/mui/autocomplete/index.tsx
+++ b/packages/rhf-mui-components/src/mui/autocomplete/index.tsx
@@ -128,7 +128,7 @@ export type RHFAutocompleteProps<
    */
   registerOptions?: RegisterOptions<T, Path<T>>;
   /**
-   * Options rendered by the field.
+   * A list of options that will be shown in the Autocomplete.
    */
   options: Option[];
   /**
@@ -205,7 +205,7 @@ export type RHFAutocompleteProps<
    */
   label?: ReactNode;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component instead of within the field layout.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui/checkbox-group/index.tsx
+++ b/packages/rhf-mui-components/src/mui/checkbox-group/index.tsx
@@ -161,8 +161,12 @@ export type RHFCheckboxGroupProps<
    * Label content shown for the field. Defaults to a label generated from `fieldName`.
    */
   label?: ReactNode;
-  /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+  /*
+   * Whether the field label renders above the checkbox group. The group has no
+   * built-in inline label, so this defaults to `true`; pass `false` to hide the
+   * visible label (the accessible name is still applied).
+   *
+   * @default true
    */
   showLabelAboveFormField?: boolean;
   /**
@@ -255,7 +259,7 @@ const RHFCheckboxGroup = <
   hideErrorMessage,
   helperText,
   formHelperTextProps,
-  onBlur: muiOnBlur,
+  onBlur,
   customIds
 }: RHFCheckboxGroupProps<T, Option, LabelKey, ValueKey>) => {
   const {
@@ -362,7 +366,7 @@ const RHFCheckboxGroup = <
               const relatedTarget = e.relatedTarget as Node | null;
               if (!currentTarget.contains(relatedTarget)) {
                 rhfOnBlur();
-                muiOnBlur?.(e);
+                onBlur?.(e);
               }
             }}
           >

--- a/packages/rhf-mui-components/src/mui/country-select/index.tsx
+++ b/packages/rhf-mui-components/src/mui/country-select/index.tsx
@@ -195,7 +195,7 @@ export type RHFCountrySelectProps<
    */
   label?: ReactNode;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component instead of within the field layout.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui/country-select/index.tsx
+++ b/packages/rhf-mui-components/src/mui/country-select/index.tsx
@@ -503,7 +503,7 @@ ref: Ref<HTMLInputElement>) {
                     {...otherTextFieldProps}
                     {...otherInputParams}
                     label={
-                      !isLabelAboveFormField
+                      !hideLabel && !isLabelAboveFormField
                         ? (
                           <FormLabelText label={fieldLabel} required={required} />
                         )

--- a/packages/rhf-mui-components/src/mui/country-select/index.tsx
+++ b/packages/rhf-mui-components/src/mui/country-select/index.tsx
@@ -141,9 +141,9 @@ export type RHFCountrySelectProps<
    */
   preferredCountries?: CountryISO[];
   /**
-   * - When `valueKey` is provided, selected value(s) are stored using the
+   * - When `valueKey` is provided, selected value(s) are exposed using the
    *   specified country property.
-   * - When `valueKey` is omitted, selected value(s) are stored as complete
+   * - When `valueKey` is omitted, selected value(s) are exposed as complete
    *   country objects.
    */
   valueKey?: keyof Omit<CountryDetails, 'emoji'>;

--- a/packages/rhf-mui-components/src/mui/file-uploader/index.tsx
+++ b/packages/rhf-mui-components/src/mui/file-uploader/index.tsx
@@ -262,7 +262,7 @@ export type RHFFileUploaderProps<T extends FieldValues> = {
    */
   label?: ReactNode;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui/file-uploader/index.tsx
+++ b/packages/rhf-mui-components/src/mui/file-uploader/index.tsx
@@ -262,7 +262,8 @@ export type RHFFileUploaderProps<T extends FieldValues> = {
    */
   label?: ReactNode;
   /**
-   * When `true`, renders the label above the component.
+   * Renders the label above the component.
+   * @default true
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui/index.ts
+++ b/packages/rhf-mui-components/src/mui/index.ts
@@ -17,6 +17,9 @@ import RHFFileUploader, {
 import RHFMultiAutocomplete, {
   type RHFMultiAutocompleteProps,
 } from './multi-autocomplete';
+import RHFMultiAutocompleteObject, {
+  type RHFMultiAutocompleteObjectProps,
+} from './multi-autocomplete-object';
 import RHFNativeSelect, { type RHFNativeSelectProps } from './native-select';
 import RHFNumberInput, { type RHFNumberInputProps } from './number-input';
 import RHFPasswordInput, { type RHFPasswordInputProps } from './password-input';
@@ -37,6 +40,7 @@ export {
   RHFCountrySelect,
   RHFFileUploader,
   RHFMultiAutocomplete,
+  RHFMultiAutocompleteObject,
   RHFNativeSelect,
   RHFNumberInput,
   RHFPasswordInput,
@@ -62,6 +66,7 @@ export type {
   ExistingUploadedFile,
   FileUploadErrorDetails,
   RHFMultiAutocompleteProps,
+  RHFMultiAutocompleteObjectProps,
   RHFNativeSelectProps,
   RHFNumberInputProps,
   RHFPasswordInputProps,

--- a/packages/rhf-mui-components/src/mui/multi-autocomplete-object/index.tsx
+++ b/packages/rhf-mui-components/src/mui/multi-autocomplete-object/index.tsx
@@ -111,7 +111,7 @@ export type RHFMultiAutocompleteObjectProps<
    */
   registerOptions?: RegisterOptions<T, Path<T>>;
   /**
-   * Options rendered by the field.
+   * An array of options displayed in the autocomplete dropdown for multiple selection.
    */
   options: Option[];
   /**
@@ -164,7 +164,7 @@ export type RHFMultiAutocompleteObjectProps<
    */
   label?: ReactNode;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component instead of within the field layout.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui/multi-autocomplete-object/index.tsx
+++ b/packages/rhf-mui-components/src/mui/multi-autocomplete-object/index.tsx
@@ -565,7 +565,7 @@ const RHFMultiAutocompleteObjectInner = forwardRef(function RHFMultiAutocomplete
                     }
                     {...otherInputParams}
                     label={
-                      !isLabelAboveFormField
+                      !hideLabel && !isLabelAboveFormField
                         ? (
                           <FormLabelText label={fieldLabel} required={required} />
                         )

--- a/packages/rhf-mui-components/src/mui/multi-autocomplete/index.tsx
+++ b/packages/rhf-mui-components/src/mui/multi-autocomplete/index.tsx
@@ -111,7 +111,7 @@ export type RHFMultiAutocompleteProps<
    */
   registerOptions?: RegisterOptions<T, Path<T>>;
   /**
-   * Options rendered by the field.
+   * An array of options displayed in the autocomplete dropdown for multiple selection.
    */
   options: Option[];
   /**
@@ -181,7 +181,7 @@ export type RHFMultiAutocompleteProps<
     state: AutocompleteRenderOptionState
   ) => ReactNode;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component instead of within the field layout.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui/multi-autocomplete/index.tsx
+++ b/packages/rhf-mui-components/src/mui/multi-autocomplete/index.tsx
@@ -593,7 +593,7 @@ const RHFMultiAutocompleteInner = forwardRef(function RHFMultiAutocomplete<
                       selectedOptions.length > 0 ? undefined : placeholder
                     }
                     label={
-                      !isLabelAboveFormField
+                      !hideLabel && !isLabelAboveFormField
                         ? (
                           <FormLabelText label={fieldLabel} required={required} />
                         )

--- a/packages/rhf-mui-components/src/mui/native-select/index.tsx
+++ b/packages/rhf-mui-components/src/mui/native-select/index.tsx
@@ -157,7 +157,7 @@ export type RHFNativeSelectProps<
    */
   label?: ReactNode;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui/native-select/index.tsx
+++ b/packages/rhf-mui-components/src/mui/native-select/index.tsx
@@ -157,7 +157,8 @@ export type RHFNativeSelectProps<
    */
   label?: ReactNode;
   /**
-   * When `true`, renders the label above the component.
+   * Renders the label above the component.
+   * @default true
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui/number-input/index.tsx
+++ b/packages/rhf-mui-components/src/mui/number-input/index.tsx
@@ -101,6 +101,7 @@ function isNativeNumberMarkerClick(
  * `nonNegative` is false; digits; optional decimal with length limit.
  * @param nonNegative - When `true`, only non-negative values (including 0) match
  *   while typing. When `false` or omitted, `-` and negative numbers are allowed.
+ * @param onlyIntegers - When `true`, decimal values are blocked.
  * @param maxDecimalPlaces - The maximum number of decimal places allowed.
  * @returns A RegExp pattern for in-progress typing.
  */
@@ -177,7 +178,7 @@ export type RHFNumberInputProps<T extends FieldValues> = {
   /**
    * When `true`, negative and exponential values are not allowed
    * while typing or pasting.
-  */
+   */
   nonNegative?: boolean;
   /**
    * Maximum number of decimal places allowed. When set, the user cannot type

--- a/packages/rhf-mui-components/src/mui/number-input/index.tsx
+++ b/packages/rhf-mui-components/src/mui/number-input/index.tsx
@@ -159,7 +159,7 @@ export type RHFNumberInputProps<T extends FieldValues> = {
    */
   onValueChange?: ({ newValue, event }: OnValueChangeProps) => void;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component instead of within the field layout.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui/password-input/index.tsx
+++ b/packages/rhf-mui-components/src/mui/password-input/index.tsx
@@ -37,17 +37,17 @@ import {
 } from '@/common';
 import { RHFMuiConfigContext } from '@/config/ConfigProvider';
 import type { CustomComponentIds } from '@/types';
-
-type OnValueChangeProps = {
-  newValue: string;
-  event: ChangeEvent<HTMLInputElement>;
-};
 import {
   fieldNameToLabel,
   keepLabelAboveFormField,
   mergeRefs,
   useFieldIds
 } from '@/utils';
+
+type OnValueChangeProps = {
+  newValue: string;
+  event: ChangeEvent<HTMLInputElement>;
+};
 
 type InputPasswordProps = Omit<
   TextFieldProps,

--- a/packages/rhf-mui-components/src/mui/password-input/index.tsx
+++ b/packages/rhf-mui-components/src/mui/password-input/index.tsx
@@ -101,7 +101,7 @@ export type RHFPasswordInputProps<T extends FieldValues> = {
    */
   onValueChange?: ({ newValue, event }: OnValueChangeProps) => void;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component instead of within the field layout.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui/radio-group/index.tsx
+++ b/packages/rhf-mui-components/src/mui/radio-group/index.tsx
@@ -144,7 +144,8 @@ export type RHFRadioGroupProps<
    */
   label?: ReactNode;
   /**
-   * When `true`, renders the label above the component.
+   * Renders the label above the component.
+   * @default true
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui/radio-group/index.tsx
+++ b/packages/rhf-mui-components/src/mui/radio-group/index.tsx
@@ -144,7 +144,7 @@ export type RHFRadioGroupProps<
    */
   label?: ReactNode;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui/rating/index.tsx
+++ b/packages/rhf-mui-components/src/mui/rating/index.tsx
@@ -94,7 +94,7 @@ export type RHFRatingProps<T extends FieldValues> = {
    */
   label?: ReactNode;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui/rating/index.tsx
+++ b/packages/rhf-mui-components/src/mui/rating/index.tsx
@@ -94,7 +94,8 @@ export type RHFRatingProps<T extends FieldValues> = {
    */
   label?: ReactNode;
   /**
-   * When `true`, renders the label above the component.
+   * Renders the label above the component.
+   * @default true
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui/select/index.tsx
+++ b/packages/rhf-mui-components/src/mui/select/index.tsx
@@ -179,7 +179,7 @@ export type RHFSelectProps<
     child
   }: OnValueChangeProps<Option, ValueKey, Multiple>) => void;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component instead of within the field layout.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui/slider/index.tsx
+++ b/packages/rhf-mui-components/src/mui/slider/index.tsx
@@ -99,7 +99,7 @@ export type RHFSliderProps<T extends FieldValues> = {
    */
   label?: ReactNode;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui/slider/index.tsx
+++ b/packages/rhf-mui-components/src/mui/slider/index.tsx
@@ -99,7 +99,8 @@ export type RHFSliderProps<T extends FieldValues> = {
    */
   label?: ReactNode;
   /**
-   * When `true`, renders the label above the component.
+   * Renders the label above the component.
+   * @default true
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui/tags-input/index.tsx
+++ b/packages/rhf-mui-components/src/mui/tags-input/index.tsx
@@ -243,7 +243,7 @@ export type RHFTagsInputProps<T extends FieldValues> = {
   customIds?: CustomComponentIds;
 } & TextFieldInputProps;
 
-type RhfOnChange = (value: string[]) => void;
+type RHFOnChange = (value: string[]) => void;
 
 const RHFTagsInputInner = forwardRef(function RHFTagsInput<
   T extends FieldValues
@@ -360,7 +360,7 @@ const RHFTagsInputInner = forwardRef(function RHFTagsInput<
 
   /** Helper for triggering both RHF + external change events */
   const triggerChangeEvents = useCallback(
-    (newValue: string[], onChange: RhfOnChange) => {
+    (newValue: string[], onChange: RHFOnChange) => {
       onChange(newValue);
       onValueChange?.({ newValue });
     },
@@ -371,7 +371,7 @@ const RHFTagsInputInner = forwardRef(function RHFTagsInput<
     (
       event: KeyboardEvent<HTMLDivElement>,
       value: string[],
-      onChange: RhfOnChange
+      onChange: RHFOnChange
     ) => {
       const trimmed = inputValue.trim();
 
@@ -449,7 +449,7 @@ const RHFTagsInputInner = forwardRef(function RHFTagsInput<
     (
       event: ClipboardEvent<HTMLDivElement>,
       value: string[],
-      onChange: RhfOnChange
+      onChange: RHFOnChange
     ) => {
       event.preventDefault();
       const pasteData = event.clipboardData.getData('text');
@@ -568,7 +568,7 @@ const RHFTagsInputInner = forwardRef(function RHFTagsInput<
                   }
                   triggerChangeEvents(
                     rhfValue.filter(t => t !== tag),
-                    rhfOnChange as RhfOnChange
+                    rhfOnChange as RHFOnChange
                   );
                 }}
               />
@@ -608,6 +608,7 @@ const RHFTagsInputInner = forwardRef(function RHFTagsInput<
               {...otherTagsInputProps}
               id={fieldId}
               name={rhfFieldName}
+              type="text"
               autoComplete={autoComplete}
               inputRef={mergeRefs(rhfRef, ref)}
               variant={variant}
@@ -621,9 +622,9 @@ const RHFTagsInputInner = forwardRef(function RHFTagsInput<
               value={inputValue}
               onChange={handleInputChange}
               onKeyDown={event =>
-                handleKeyDown(event, rhfValue, rhfOnChange as RhfOnChange)}
+                handleKeyDown(event, rhfValue, rhfOnChange as RHFOnChange)}
               onPaste={event =>
-                handlePaste(event, rhfValue, rhfOnChange as RhfOnChange)}
+                handlePaste(event, rhfValue, rhfOnChange as RHFOnChange)}
               onFocus={handleFocus}
               onBlur={e => {
                 setIsFocused(false);

--- a/packages/rhf-mui-components/src/mui/tags-input/index.tsx
+++ b/packages/rhf-mui-components/src/mui/tags-input/index.tsx
@@ -174,7 +174,7 @@ export type RHFTagsInputProps<T extends FieldValues> = {
    */
   onValueChange?: ({ newValue }: OnValueChangeProps) => void;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component instead of within the field layout.
    */
   showLabelAboveFormField?: boolean;
   /**

--- a/packages/rhf-mui-components/src/mui/textfield/index.tsx
+++ b/packages/rhf-mui-components/src/mui/textfield/index.tsx
@@ -80,7 +80,7 @@ export type RHFTextFieldProps<T extends FieldValues> = {
    */
   onValueChange?: ({ newValue, event }: OnValueChangeProps) => void;
   /**
-   * When true, renders the field label above the form field instead of inside or beside it.
+   * When `true`, renders the label above the component instead of within the field layout.
    */
   showLabelAboveFormField?: boolean;
   /**


### PR DESCRIPTION
### ✨ Enhancements
- Improved JSDoc for the `options` prop in `RHFAutocomplete`, `RHFAutocompleteObject`, `RHFMultiAutocomplete`, and `RHFMultiAutocompleteObject`.
- Refined the JSDoc wording for the `showLabelAboveFormField` prop across all component.

### 🐞 Bug Fixes
- Added missing exports for `RHFMultiAutocompleteObject` and `RHFMultiAutocompleteObjectProps` to the `mui` index module.
- Fix Autocomplete components to fully respect `hideLabel` by preventing inline MUI TextField labels from rendering when labels are hidden.
- Removed the `id` prop from `RHFRichTextEditor`, as the internally generated field id was already being assigned to the `CKEditor` instance.