### PR TITLE
v3.4.4 - generic onValueChange for fileuploader and autocompletes; bugfix for TagsInput

### DIFF
--- a/.github/workflows/build-demo.yml
+++ b/.github/workflows/build-demo.yml
@@ -10,7 +10,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Configure Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: yarn

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Configure Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: yarn

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v7
       - name: Setup Node env
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ build
 dist
 *.tsbuildinfo
 
+# AI Agents
+.claude
+
 # testing
 coverage
 .nyc_output

--- a/apps/rhf-mui-demo/package.json
+++ b/apps/rhf-mui-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-demo",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "private": true,
   "author": "Nishant Kohli",
   "scripts": {

--- a/apps/rhf-mui-demo/src/forms/autocomplete/index.tsx
+++ b/apps/rhf-mui-demo/src/forms/autocomplete/index.tsx
@@ -238,7 +238,7 @@ const AutocompleteForm = () => {
               }}
               options={pokemonList}
               labelKey="name"
-              valueKey="id"
+              valueKey="name"
               multiple
               showLabelAboveFormField
               loading={loading}

--- a/apps/rhf-mui-docs/docs/components/mui/RHFCountrySelect.mdx
+++ b/apps/rhf-mui-docs/docs/components/mui/RHFCountrySelect.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 10
 sidebar_label: Country Select
 title: RHFCountrySelect
 description: Customizable autocomplete field that allows user to select one or more countries.

--- a/apps/rhf-mui-docs/docs/components/mui/RHFMultiAutocomplete.mdx
+++ b/apps/rhf-mui-docs/docs/components/mui/RHFMultiAutocomplete.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 11
 sidebar_label: Multi Autocomplete
 title: RHFMultiAutocomplete
 description: Customizable multi-select autocomplete with 'Select All' support and flexible options as arrays or object arrays, best used for large datasets.

--- a/apps/rhf-mui-docs/docs/components/mui/RHFMultiAutocompleteObject.mdx
+++ b/apps/rhf-mui-docs/docs/components/mui/RHFMultiAutocompleteObject.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 12
 sidebar_label: Multi Autocomplete Object
 title: RHFMultiAutocompleteObject
 description: Multi-select autocomplete component with object-based values and built-in "Select All" functionality.

--- a/apps/rhf-mui-docs/package.json
+++ b/apps/rhf-mui-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-docs",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/apps/rhf-mui-docs/versioned_docs/version-v2/components/mui/RHFCountrySelect.mdx
+++ b/apps/rhf-mui-docs/versioned_docs/version-v2/components/mui/RHFCountrySelect.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 9
 sidebar_label: Country Select
 title: RHFCountrySelect
 description: Customizable autocomplete field that allows user to select one or more countries.

--- a/apps/rhf-mui-docs/versioned_docs/version-v2/components/mui/RHFMultiAutocomplete.mdx
+++ b/apps/rhf-mui-docs/versioned_docs/version-v2/components/mui/RHFMultiAutocomplete.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 10
 sidebar_label: Multi Autocomplete
 title: RHFMultiAutocomplete
 description: Customizable multi-select autocomplete with 'Select All' support and flexible options as arrays or object arrays, best used for large datasets.

--- a/changelog/v3.md
+++ b/changelog/v3.md
@@ -1,5 +1,12 @@
 # Changelog - v3
 
+## [3.4.4](https://github.com/nishkohli96/rhf-mui-components/tree/v3.4.4)
+
+**Released - 10 July, 2026**
+
+### 🐞 Bug Fixes
+- `RHFTagsInput`: Fixed issue where input would loose focus (and fail to remove the tag) when deleting a chip beyond the collapsed `limitTags` count while focused.
+
 ## [3.4.3](https://github.com/nishkohli96/rhf-mui-components/tree/v3.4.3)
 
 **Released - 10 July, 2026**

--- a/changelog/v3.md
+++ b/changelog/v3.md
@@ -2,10 +2,12 @@
 
 ## [3.4.4](https://github.com/nishkohli96/rhf-mui-components/tree/v3.4.4)
 
-**Released - 10 July, 2026**
+**Released - 17 July, 2026**
 
 ### 🐞 Bug Fixes
 - `RHFTagsInput`: Fixed issue where input would loose focus (and fail to remove the tag) when deleting a chip beyond the collapsed `limitTags` count while focused.
+- `RHFFileUploader`: onValueChange's `acceptedFiles` param is now generic on `multiple`, typed as `File[] | null` when `multiple` is `true` and `File | null` otherwise.
+
 
 ## [3.4.3](https://github.com/nishkohli96/rhf-mui-components/tree/v3.4.3)
 

--- a/changelog/v3.md
+++ b/changelog/v3.md
@@ -7,6 +7,7 @@
 ### ✨ Enhancements
 - `RHFFileUploader`: onValueChange's `acceptedFiles` param is now generic on `multiple`, typed as `File[] | null` when `multiple` is `true`, and `File | null` otherwise.
 - `RHFAutocomplete`, `RHFAutocompleteObject` & `RHFCountrySelect`: `onValueChange` value param is now generic on `multiple`.
+- Bump `actions/setup-node` from `v6` to `v7`.
 
 ### 🐞 Bug Fixes
 - `RHFTagsInput`: Fixed issue where input would loose focus (and fail to remove the tag) when deleting a chip beyond the collapsed `limitTags` count while focused.

--- a/changelog/v3.md
+++ b/changelog/v3.md
@@ -4,9 +4,12 @@
 
 **Released - 17 July, 2026**
 
+### ✨ Enhancements
+- `RHFFileUploader`: onValueChange's `acceptedFiles` param is now generic on `multiple`, typed as `File[] | null` when `multiple` is `true`, and `File | null` otherwise.
+- `RHFAutocomplete`, `RHFAutocompleteObject` & `RHFCountrySelect`: `onValueChange` value param is now generic on `multiple`.
+
 ### 🐞 Bug Fixes
 - `RHFTagsInput`: Fixed issue where input would loose focus (and fail to remove the tag) when deleting a chip beyond the collapsed `limitTags` count while focused.
-- `RHFFileUploader`: onValueChange's `acceptedFiles` param is now generic on `multiple`, typed as `File[] | null` when `multiple` is `true` and `File | null` otherwise.
 
 
 ## [3.4.3](https://github.com/nishkohli96/rhf-mui-components/tree/v3.4.3)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-components-root",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "description": "A suite of 20+ production-ready react-hook-form components built with material-ui. Fully typed, tree-shakable, and optimized for enterprise-grade forms.",
   "author": "Nishant Kohli",
   "private": true,

--- a/packages/rhf-mui-components/package.json
+++ b/packages/rhf-mui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-components",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "description": "A suite of 20+ production-ready react-hook-form components built with material-ui. Fully typed, tree-shakable, and optimized for enterprise-grade forms.",
   "author": "Nishant Kohli",
   "homepage": "https://rhf-mui-components.vercel.app/",

--- a/packages/rhf-mui-components/src/mui/autocomplete-object/index.tsx
+++ b/packages/rhf-mui-components/src/mui/autocomplete-object/index.tsx
@@ -72,6 +72,9 @@ type AutocompleteFieldValue<
   DisableClearable extends boolean,
 > = AutocompleteValue<Option, Multiple, DisableClearable, false>;
 
+type AutocompleteObjectFieldChangeValue<Option, Multiple extends boolean>
+  = Multiple extends true ? Option[] : (Option | null);
+
 export type RHFAutocompleteObjectProps<
   T extends FieldValues,
   Option extends KeyValueOption = KeyValueOption,
@@ -115,13 +118,14 @@ export type RHFAutocompleteObjectProps<
   disableClearable?: DisableClearable;
   /**
    * Callback fired after the selected option object value is stored in the field.
-   * @param fieldValue - Selected option object, selected option objects, or `null` when cleared.
+   * @param fieldValue - Selected option object(s), typed as `Option[]` when
+   * `multiple` is `true` and `Option | null` otherwise.
    * @param event - MUI autocomplete change event.
    * @param reason - Reason reported by MUI for the value change.
    * @param details - Optional MUI details for the changed option.
    */
   onValueChange?: (
-    fieldValue: Option | Option[] | null,
+    fieldValue: AutocompleteObjectFieldChangeValue<Option, Multiple>,
     event: SyntheticEvent<Element, Event>,
     reason: AutocompleteChangeReason,
     details?: AutocompleteChangeDetails<Option>
@@ -300,11 +304,13 @@ const RHFAutocompleteObject = <
                 reason: AutocompleteChangeReason,
                 details?: AutocompleteChangeDetails<Option>
               ) => {
-                const fieldValue = newValue === null
-                  ? null
-                  : Array.isArray(newValue)
-                    ? newValue as Option[]
-                    : newValue as Option;
+                const fieldValue = (
+                  newValue === null
+                    ? null
+                    : Array.isArray(newValue)
+                      ? newValue as Option[]
+                      : newValue as Option
+                ) as AutocompleteObjectFieldChangeValue<Option, Multiple>;
                 rhfOnChange(newValue);
                 onValueChange?.(fieldValue, event, reason, details);
               }}

--- a/packages/rhf-mui-components/src/mui/autocomplete/index.tsx
+++ b/packages/rhf-mui-components/src/mui/autocomplete/index.tsx
@@ -77,6 +77,9 @@ type AutocompleteFieldValue<
   DisableClearable extends boolean,
 > = AutocompleteValue<Option, Multiple, DisableClearable, false>;
 
+type AutocompleteFieldChangeValue<Multiple extends boolean>
+  = Multiple extends true ? string[] : (string | null);
+
 export type RHFAutocompleteProps<
   T extends FieldValues,
   Option extends StrObjOption = StrObjOption,
@@ -120,13 +123,14 @@ export type RHFAutocompleteProps<
   disableClearable?: DisableClearable;
   /**
    * Callback fired after the autocomplete value is normalized and stored in the field.
-   * @param fieldValue - Normalized selected value, selected values, or `null` when cleared.
+   * @param fieldValue - Normalized selected value, typed as `string[]` when
+   * `multiple` is `true` and `string | null` otherwise.
    * @param event - MUI autocomplete change event.
    * @param reason - Reason reported by MUI for the value change.
    * @param details - Optional MUI details for the changed option.
    */
   onValueChange?: (
-    fieldValue: string | string[] | null,
+    fieldValue: AutocompleteFieldChangeValue<Multiple>,
     event: SyntheticEvent<Element, Event>,
     reason: AutocompleteChangeReason,
     details?: AutocompleteChangeDetails<Option>
@@ -326,8 +330,8 @@ const RHFAutocomplete = <
                 reason: AutocompleteChangeReason,
                 details?: AutocompleteChangeDetails<Option>
               ) => {
-                const fieldValue
-                  = newValue === null
+                const fieldValue = (
+                  newValue === null
                     ? null
                     : Array.isArray(newValue)
                       ? (newValue ?? []).map(item =>
@@ -337,7 +341,8 @@ const RHFAutocomplete = <
                       : valueKey
                         && isKeyValueOption(newValue, labelKey, valueKey)
                         ? newValue[valueKey]
-                        : (newValue as string);
+                        : (newValue as string)
+                ) as AutocompleteFieldChangeValue<Multiple>;
                 rhfOnChange(fieldValue);
                 onValueChange?.(fieldValue, event, reason, details);
               }}

--- a/packages/rhf-mui-components/src/mui/country-select/index.tsx
+++ b/packages/rhf-mui-components/src/mui/country-select/index.tsx
@@ -78,6 +78,9 @@ type AutocompleteFieldValue<
   DisableClearable extends boolean,
 > = AutocompleteValue<CountryDetails, Multiple, DisableClearable, false>;
 
+type CountrySelectFieldChangeValue<Multiple extends boolean>
+  = Multiple extends true ? CountryDetails[] : (CountryDetails | null);
+
 export type RHFCountrySelectProps<
   T extends FieldValues,
   Multiple extends boolean = false,
@@ -127,13 +130,14 @@ export type RHFCountrySelectProps<
   disableClearable?: DisableClearable;
   /**
    * Callback fired after the selected country value is stored in the field.
-   * @param newValue - Selected country object, selected country objects, or `null` when cleared.
+   * @param newValue - Selected country object(s), typed as `CountryDetails[]`
+   * when `multiple` is `true` and `CountryDetails | null` otherwise.
    * @param event - MUI autocomplete change event.
    * @param reason - Reason reported by MUI for the value change.
    * @param details - Optional MUI details for the changed country.
    */
   onValueChange?: (
-    newValue: CountryDetails | CountryDetails[] | null,
+    newValue: CountrySelectFieldChangeValue<Multiple>,
     event: SyntheticEvent,
     reason: AutocompleteChangeReason,
     details?: AutocompleteChangeDetails<CountryDetails>
@@ -317,7 +321,7 @@ const RHFCountrySelect = <
                   : (newValue as CountryDetails)?.[valueKey] ?? null;
                 rhfOnChange(newValueKey);
                 onValueChange?.(
-                  newValue as CountryDetails | CountryDetails[] | null,
+                  newValue as CountrySelectFieldChangeValue<Multiple>,
                   event,
                   reason,
                   details

--- a/packages/rhf-mui-components/src/mui/file-uploader/index.tsx
+++ b/packages/rhf-mui-components/src/mui/file-uploader/index.tsx
@@ -36,7 +36,13 @@ export enum FileUploadError {
   limitExceeded = 'FILE_LIMIT_EXCEEDED',
 }
 
-export type RHFFileUploaderProps<T extends FieldValues> = {
+type FileUploadValue<Multiple extends boolean>
+  = Multiple extends true ? File[] : File;
+
+export type RHFFileUploaderProps<
+  T extends FieldValues,
+  Multiple extends boolean = false,
+> = {
   /**
    * Name/path of the React Hook Form field this component controls.
    */
@@ -65,7 +71,7 @@ export type RHFFileUploaderProps<T extends FieldValues> = {
   /**
    * When true, allows selecting multiple files.
    */
-  multiple?: boolean;
+  multiple?: Multiple;
   /**
    * Maximum file size (in bytes) eligible for upload.
    * Files exceeding this size will be rejected and trigger an error callback.
@@ -112,11 +118,12 @@ export type RHFFileUploaderProps<T extends FieldValues> = {
   ) => ReactNode;
   /**
    * Callback fired after accepted file input value is stored in the field.
-   * @param acceptedFiles - Accepted file, accepted files, or `null` when no file is selected.
+   * @param acceptedFiles - Accepted file(s), typed as `File[]` when `multiple`
+   * is `true` and `File` otherwise, or `null` when no file is selected.
    * @param event - File input change event.
    */
   onValueChange?: (
-    acceptedFiles: File | File[] | null,
+    acceptedFiles: FileUploadValue<Multiple> | null,
     event: ChangeEvent<HTMLInputElement>
   ) => void;
   /**
@@ -162,7 +169,10 @@ export type RHFFileUploaderProps<T extends FieldValues> = {
   fullWidth?: boolean;
 };
 
-const RHFFileUploader = <T extends FieldValues>({
+const RHFFileUploader = <
+  T extends FieldValues,
+  Multiple extends boolean = false,
+>({
   fieldName,
   control,
   registerOptions,
@@ -186,7 +196,7 @@ const RHFFileUploader = <T extends FieldValues>({
   hideErrorMessage,
   formHelperTextProps,
   fullWidth = false
-}: RHFFileUploaderProps<T>) => {
+}: RHFFileUploaderProps<T, Multiple>) => {
   const {
     fieldId,
     labelId,
@@ -244,11 +254,13 @@ const RHFFileUploader = <T extends FieldValues>({
             onUploadError?.(errors, rejectedFiles);
           }
 
-          const selectedFiles = multiple
-            ? acceptedFiles.length > 0
-              ? acceptedFiles
-              : null
-            : (acceptedFiles[0] ?? null);
+          const selectedFiles = (
+            multiple
+              ? acceptedFiles.length > 0
+                ? acceptedFiles
+                : null
+              : (acceptedFiles[0] ?? null)
+          ) as FileUploadValue<Multiple> | null;
           rhfOnChange(selectedFiles);
           onValueChange?.(selectedFiles, event);
           /* Reset so same file can be selected again */

--- a/packages/rhf-mui-components/src/mui/tags-input/index.tsx
+++ b/packages/rhf-mui-components/src/mui/tags-input/index.tsx
@@ -279,6 +279,7 @@ const RHFTagsInput = <T extends FieldValues>({
         const startAdornment = (
           <Box
             role="list"
+            onMouseDown={event => event.preventDefault()}
             sx={{
               display: 'flex',
               flexWrap: 'wrap',


### PR DESCRIPTION
### ✨ Enhancements
- `RHFFileUploader`: onValueChange's `acceptedFiles` param is now generic on `multiple`, typed as `File[] | null` when `multiple` is `true`, and `File | null` otherwise.
- `RHFAutocomplete`, `RHFAutocompleteObject` & `RHFCountrySelect`: `onValueChange` value param is now generic on `multiple`.
- Bump `actions/setup-node` from `v6` to `v7`.

### 🐞 Bug Fixes
- `RHFTagsInput`: Fixed issue where input would loose focus (and fail to remove the tag) when deleting a chip beyond the collapsed `limitTags` count while focused.
