### PR TITLE
v3.5.0 - readOnly prop for PasswordInput, update onValueChange for Slider

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@
   <img alt="License" src="https://img.shields.io/badge/License-MIT-blue.svg" />
 </p>
 
+>Looking for the same components without react-hook-form?
+>
+>Check out [@nish1896/mui-components](https://www.npmjs.com/package/@nish1896/mui-components) — a standalone collection of fully controlled Material UI components with a familiar API and comprehensive documentation.
+
 ## Features ✨
 
 - Each component is fully functional with just 3-4 props — core logic handled internally.

--- a/apps/rhf-mui-demo/package.json
+++ b/apps/rhf-mui-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-demo",
-  "version": "3.4.4",
+  "version": "3.5.0",
   "private": true,
   "author": "Nishant Kohli",
   "scripts": {

--- a/apps/rhf-mui-docs/package.json
+++ b/apps/rhf-mui-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-docs",
-  "version": "3.4.4",
+  "version": "3.5.0",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/changelog/v3.md
+++ b/changelog/v3.md
@@ -1,5 +1,14 @@
 # Changelog - v3
 
+## [3.5.0](https://github.com/nishkohli96/rhf-mui-components/tree/v3.5.0)
+
+**Released - 31 July, 2026**
+
+### ✨ Enhancements
+- `RHFPasswordInput`: Added a `readOnly` prop to allow password visibility toggling while the input is disabled.
+- `RHFSlider`: Updated `onValueChange` so the emitted `value` matches the field's value type.
+
+
 ## [3.4.4](https://github.com/nishkohli96/rhf-mui-components/tree/v3.4.4)
 
 **Released - 17 July, 2026**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-components-root",
-  "version": "3.4.4",
+  "version": "3.5.0",
   "description": "A suite of 20+ production-ready react-hook-form components built with material-ui. Fully typed, tree-shakable, and optimized for enterprise-grade forms.",
   "author": "Nishant Kohli",
   "private": true,

--- a/packages/rhf-mui-components/README.md
+++ b/packages/rhf-mui-components/README.md
@@ -17,6 +17,10 @@
   <img alt="License" src="https://img.shields.io/badge/License-MIT-blue.svg" />
 </p>
 
+>Looking for the same components without react-hook-form?
+>
+>Check out [@nish1896/mui-components](https://www.npmjs.com/package/@nish1896/mui-components) — a standalone collection of fully controlled Material UI components with a familiar API and comprehensive documentation.
+
 ## Features ✨
 
 - Each component is fully functional with just 3-4 props — core logic handled internally.

--- a/packages/rhf-mui-components/package.json
+++ b/packages/rhf-mui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-components",
-  "version": "3.4.4",
+  "version": "3.5.0",
   "description": "A suite of 20+ production-ready react-hook-form components built with material-ui. Fully typed, tree-shakable, and optimized for enterprise-grade forms.",
   "author": "Nishant Kohli",
   "homepage": "https://rhf-mui-components.vercel.app/",

--- a/packages/rhf-mui-components/src/mui/password-input/index.tsx
+++ b/packages/rhf-mui-components/src/mui/password-input/index.tsx
@@ -93,6 +93,15 @@ export type RHFPasswordInputProps<T extends FieldValues> = {
    */
   hidePasswordIcon?: ReactNode;
   /**
+   * When true, the value is displayed but cannot be edited.
+   *
+   * Unlike `disabled`, the field stays focusable, is still submitted with the
+   * form, and the show/hide toggle remains usable — a read-only value is
+   * meaningful, so the user can still reveal it to verify it. `disabled`
+   * instead makes the whole field inert, including the toggle.
+   */
+  readOnly?: boolean;
+  /**
    * Validation error message displayed in the `FormHelperText` component.
    * When provided, it takes precedence over `helperText` unless
    * `hideErrorMessage` is set to `true`.
@@ -119,6 +128,7 @@ const RHFPasswordInput = <T extends FieldValues>({
   formLabelProps,
   showPasswordIcon,
   hidePasswordIcon,
+  readOnly,
   required,
   helperText,
   errorMessage,
@@ -178,7 +188,8 @@ const RHFPasswordInput = <T extends FieldValues>({
               ? errorId
               : helperTextId
             : undefined,
-          'aria-required': required
+          'aria-required': required,
+          'aria-readonly': readOnly || undefined
         };
 
         const endAdornment = (
@@ -242,6 +253,7 @@ const RHFPasswordInput = <T extends FieldValues>({
                     ...slotProps,
                     input: {
                       ...slotProps?.input,
+                      readOnly,
                       endAdornment
                     },
                     htmlInput: {
@@ -257,6 +269,7 @@ const RHFPasswordInput = <T extends FieldValues>({
                   },
                   InputProps: {
                     ...InputProps,
+                    readOnly,
                     endAdornment
                   }
                 })}

--- a/packages/rhf-mui-components/src/mui/slider/index.tsx
+++ b/packages/rhf-mui-components/src/mui/slider/index.tsx
@@ -5,6 +5,7 @@ import {
   Controller,
   type FieldValues,
   type Path,
+  type PathValue,
   type Control,
   type RegisterOptions
 } from 'react-hook-form';
@@ -25,11 +26,18 @@ type SliderInputProps = Omit<
   | 'onChange'
 >;
 
-export type RHFSliderProps<T extends FieldValues> = {
+export type RHFSliderProps<
+  T extends FieldValues,
+  TName extends Path<T> = Path<T>
+> = {
   /**
    * Name/path of the React Hook Form field this component controls.
+   *
+   * The field's declared type in `T` (`number` for a single-thumb slider,
+   * `number[]` for a range slider) drives the type of `onValueChange`'s
+   * `value` argument — no separate type argument needed.
    */
-  fieldName: Path<T>;
+  fieldName: TName;
   /**
    * React Hook Form control object returned by `useForm`.
    */
@@ -37,19 +45,23 @@ export type RHFSliderProps<T extends FieldValues> = {
   /**
    * Validation rules passed to React Hook Form for this field.
    */
-  registerOptions?: RegisterOptions<T, Path<T>>;
+  registerOptions?: RegisterOptions<T, TName>;
   /**
    * When true, marks the field as required in the UI and accessibility attributes.
    */
   required?: boolean;
   /**
    * Callback fired after the slider value is stored in the field.
+   *
+   * `value` mirrors the type of the `fieldName` field in your form schema: a
+   * `number` for a single-thumb slider, or `number[]` for a range slider.
+   *
    * @param value - Updated slider value, or value range when using a range slider.
    * @param activeThumb - Index of the thumb that triggered the change.
    * @param event - Slider change event.
    */
   onValueChange?: (
-    value: number | number[],
+    value: PathValue<T, TName>,
     activeThumb: number,
     event: Event,
   ) => void;
@@ -85,7 +97,10 @@ export type RHFSliderProps<T extends FieldValues> = {
   formHelperTextProps?: Omit<FormHelperTextProps, 'id'>;
 } & SliderInputProps;
 
-const RHFSlider = <T extends FieldValues>({
+const RHFSlider = <
+  T extends FieldValues,
+  TName extends Path<T> = Path<T>
+>({
   fieldName,
   control,
   registerOptions,
@@ -101,7 +116,7 @@ const RHFSlider = <T extends FieldValues>({
   formHelperTextProps,
   onBlur,
   ...otherSliderProps
-}: RHFSliderProps<T>) => {
+}: RHFSliderProps<T, TName>) => {
   const {
     fieldId,
     labelId,
@@ -153,7 +168,7 @@ const RHFSlider = <T extends FieldValues>({
               disabled={isDisabled}
               onChange={(event, value, activeThumb) => {
                 rhfOnChange(value);
-                onValueChange?.(value, activeThumb, event);
+                onValueChange?.(value as PathValue<T, TName>, activeThumb, event);
               }}
               onBlur={blurEvent => {
                 rhfOnBlur();


### PR DESCRIPTION
### ✨ Enhancements
- `RHFPasswordInput`: Added a `readOnly` prop to allow password visibility toggling while the input is disabled.
- `RHFSlider`: Updated `onValueChange` so the emitted `value` matches the field's value type.