### PR TITLE
v3.6.0 - Auto infer required from register, fix PhoneInput country dropdown and other enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 >
 >Check out [@nish1896/mui-components](https://www.npmjs.com/package/@nish1896/mui-components) — a standalone collection of fully controlled Material UI components with a familiar API and comprehensive documentation.
 
-## Features ✨
+## ✨ Features
 
 - Each component is fully functional with just 3-4 props — core logic handled internally.
 - Style individual components or apply global styles via [ConfigProvider](https://rhf-mui-components.netlify.app/customization#configprovider).
@@ -29,9 +29,9 @@
 - Comprehensive docs showcasing multiple variations for each component.
 
 
-## Explore and Get Started 🚀
+## 🚀 Explore and Get Started
 
-### Documentation 📖
+### 📖 Documentation
 Access the full documentation for rhf-mui-components, including setup instructions, API references, and examples:
 
 👉 [Documentation Site](https://rhf-mui-components.vercel.app/)

--- a/README.md
+++ b/README.md
@@ -5,16 +5,16 @@
 <h1>@nish1896/rhf-mui-components</h1>
 
 <p>
-  <b>A suite of 20+ production-ready <a href="https://mui.com/">Material UI</a> components for <a href="https://react-hook-form.com/">react-hook-form</a> — fully typed, tree-shakable, and built to cut form boilerplate down to a handful of props.</b>
-</p>
-
-<p>
   <img alt="NPM Version" src="https://img.shields.io/npm/v/%40nish1896%2Frhf-mui-components" />
   <img alt="NPM Downloads" src="https://img.shields.io/npm/dt/%40nish1896%2Frhf-mui-components" />
   <img alt="NPM Downloads Per Month" src="https://img.shields.io/npm/dm/%40nish1896%2Frhf-mui-components?color=%23e0e063" />
   <img alt="GitHub Release Date" src="https://img.shields.io/github/release-date/nishkohli96/rhf-mui-components" />
   <img alt="TypeScript Strict" src="https://img.shields.io/badge/TypeScript-Strict-3178C6?logo=typescript&logoColor=white" />
   <img alt="License" src="https://img.shields.io/badge/License-MIT-blue.svg" />
+</p>
+
+<p>
+  <b>A suite of 20+ production-ready <a href="https://mui.com/">Material UI</a> components for <a href="https://react-hook-form.com/">react-hook-form</a> — fully typed, tree-shakable, and built to cut form boilerplate down to a handful of props.</b>
 </p>
 
 >Looking for the same components without react-hook-form?

--- a/apps/rhf-mui-demo/package.json
+++ b/apps/rhf-mui-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-demo",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "private": true,
   "author": "Nishant Kohli",
   "scripts": {

--- a/apps/rhf-mui-demo/package.json
+++ b/apps/rhf-mui-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-demo",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "private": true,
   "author": "Nishant Kohli",
   "scripts": {

--- a/apps/rhf-mui-docs/package.json
+++ b/apps/rhf-mui-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-docs",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/apps/rhf-mui-docs/package.json
+++ b/apps/rhf-mui-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-docs",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/changelog/v3.md
+++ b/changelog/v3.md
@@ -7,6 +7,13 @@
 ### ✨ Enhancements
 
 - Automatically infer the required state from `register.required`, eliminating the need to manually pass the `required` prop.
+- Added `@mui/system` to `peerDependencies`.
+- `RHFFileUploader`: Added `onBlur` prop
+
+### 🐞 Bug Fixes
+- Added the `Theme` generic to `SxProps` in `MUIComponentsConfig` for improved type safety and IntelliSense support.
+- `MUIPhoneInput`: Fixed the country dropdown shifting/misaligning out of place on narrow viewports (< 440px) by anchoring it to the field itself instead of the flag trigger.
+- Added support for the `aria-required` attribute to `MUIRating` for improved accessibility.
 
 
 ## [3.5.0](https://github.com/nishkohli96/rhf-mui-components/tree/v3.5.0)

--- a/changelog/v3.md
+++ b/changelog/v3.md
@@ -8,13 +8,13 @@
 
 - Automatically infer the required state from `register.required`, eliminating the need to manually pass the `required` prop.
 - Added `@mui/system` to `peerDependencies`.
+- Added the `Theme` generic to `SxProps` in `MUIComponentsConfig` for improved type safety and IntelliSense support.
 - `RHFFileUploader`: Added `onBlur` prop
 - `RHFCheckbox` & `RHFSwitch`: The value of `aria-required` attribute is also determined from RHF's `registerOptions.required` validation.
+- Added support for the `aria-required` attribute to `MUIRating` for improved accessibility.
 
 ### 🐞 Bug Fixes
-- Added the `Theme` generic to `SxProps` in `MUIComponentsConfig` for improved type safety and IntelliSense support.
 - `MUIPhoneInput`: Fixed the country dropdown shifting/misaligning out of place on narrow viewports (< 440px) by anchoring it to the field itself instead of the flag trigger.
-- Added support for the `aria-required` attribute to `MUIRating` for improved accessibility.
 
 
 ## [3.5.0](https://github.com/nishkohli96/rhf-mui-components/tree/v3.5.0)

--- a/changelog/v3.md
+++ b/changelog/v3.md
@@ -1,5 +1,14 @@
 # Changelog - v3
 
+## [3.5.1](https://github.com/nishkohli96/rhf-mui-components/tree/v3.5.1)
+
+**Released - 3 August, 2026**
+
+### ✨ Enhancements
+
+- Automatically infer the required state from `register.required`, eliminating the need to manually pass the `required` prop.
+
+
 ## [3.5.0](https://github.com/nishkohli96/rhf-mui-components/tree/v3.5.0)
 
 **Released - 31 July, 2026**

--- a/changelog/v3.md
+++ b/changelog/v3.md
@@ -1,6 +1,6 @@
 # Changelog - v3
 
-## [3.5.1](https://github.com/nishkohli96/rhf-mui-components/tree/v3.5.1)
+## [3.6.0](https://github.com/nishkohli96/rhf-mui-components/tree/v3.6.0)
 
 **Released - 3 August, 2026**
 
@@ -9,6 +9,7 @@
 - Automatically infer the required state from `register.required`, eliminating the need to manually pass the `required` prop.
 - Added `@mui/system` to `peerDependencies`.
 - `RHFFileUploader`: Added `onBlur` prop
+- `RHFCheckbox` & `RHFSwitch`: The value of `aria-required` attribute is also determined from RHF's `registerOptions.required` validation.
 
 ### 🐞 Bug Fixes
 - Added the `Theme` generic to `SxProps` in `MUIComponentsConfig` for improved type safety and IntelliSense support.

--- a/changelog/v3.md
+++ b/changelog/v3.md
@@ -11,7 +11,7 @@
 - Added the `Theme` generic to `SxProps` in `MUIComponentsConfig` for improved type safety and IntelliSense support.
 - `RHFFileUploader`: Added `onBlur` prop
 - `RHFCheckbox` & `RHFSwitch`: The value of `aria-required` attribute is also determined from RHF's `registerOptions.required` validation.
-- Added support for the `aria-required` attribute to `MUIRating` for improved accessibility.
+- Added support for the `aria-required` attribute to `RHFFileUploader`, `MUIRating` and `MUISlider` for improved accessibility.
 
 ### 🐞 Bug Fixes
 - `MUIPhoneInput`: Fixed the country dropdown shifting/misaligning out of place on narrow viewports (< 440px) by anchoring it to the field itself instead of the flag trigger.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-components-root",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "description": "A suite of 20+ production-ready react-hook-form components built with material-ui. Fully typed, tree-shakable, and optimized for enterprise-grade forms.",
   "author": "Nishant Kohli",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-components-root",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "A suite of 20+ production-ready react-hook-form components built with material-ui. Fully typed, tree-shakable, and optimized for enterprise-grade forms.",
   "author": "Nishant Kohli",
   "private": true,

--- a/packages/rhf-mui-components/README.md
+++ b/packages/rhf-mui-components/README.md
@@ -5,16 +5,16 @@
 <h1>@nish1896/rhf-mui-components</h1>
 
 <p>
-  <b>A suite of 20+ production-ready <a href="https://mui.com/">Material UI</a> components for <a href="https://react-hook-form.com/">react-hook-form</a> — fully typed, tree-shakable, and built to cut form boilerplate down to a handful of props.</b>
-</p>
-
-<p>
   <img alt="NPM Version" src="https://img.shields.io/npm/v/%40nish1896%2Frhf-mui-components" />
   <img alt="NPM Downloads" src="https://img.shields.io/npm/dt/%40nish1896%2Frhf-mui-components" />
   <img alt="NPM Downloads Per Month" src="https://img.shields.io/npm/dm/%40nish1896%2Frhf-mui-components?color=%23e0e063" />
   <img alt="GitHub Release Date" src="https://img.shields.io/github/release-date/nishkohli96/rhf-mui-components" />
   <img alt="TypeScript Strict" src="https://img.shields.io/badge/TypeScript-Strict-3178C6?logo=typescript&logoColor=white" />
   <img alt="License" src="https://img.shields.io/badge/License-MIT-blue.svg" />
+</p>
+
+<p>
+  <b>A suite of 20+ production-ready <a href="https://mui.com/">Material UI</a> components for <a href="https://react-hook-form.com/">react-hook-form</a> — fully typed, tree-shakable, and built to cut form boilerplate down to a handful of props.</b>
 </p>
 
 >Looking for the same components without react-hook-form?

--- a/packages/rhf-mui-components/README.md
+++ b/packages/rhf-mui-components/README.md
@@ -21,7 +21,7 @@
 >
 >Check out [@nish1896/mui-components](https://www.npmjs.com/package/@nish1896/mui-components) — a standalone collection of fully controlled Material UI components with a familiar API and comprehensive documentation.
 
-## Features ✨
+## ✨ Features
 
 - Each component is fully functional with just 3-4 props — core logic handled internally.
 - Style individual components or apply global styles via [ConfigProvider](https://rhf-mui-components.vercel.app/customization#configprovider).
@@ -30,15 +30,15 @@
 
 ## Version Support
 
-**Version 3 is now in maintenance mode and will only receive bug fixes. No new features will be added to `v3`.**
+**Version 3 is now in maintenance mode and will only receive bug fixes or minor enhancements. No new major features will be added.**
 
 Version 4 is the active release line and includes the latest customization features, component upgrades, and MUI integration improvements.
 
 > Please note that support for MUI `v5` has been removed starting from **version 4**. Developers are encouraged to migrate to MUI `v6` or `v7` to access the latest features.
 
-## Explore and Get Started 🚀
+## 🚀 Explore and Get Started
 
-### Documentation 📖
+### 📖 Documentation
 Access the full documentation for rhf-mui-components, including setup instructions, API references, and examples:
 
 👉 [Documentation Site](https://rhf-mui-components.vercel.app/)

--- a/packages/rhf-mui-components/package.json
+++ b/packages/rhf-mui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-components",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "A suite of 20+ production-ready react-hook-form components built with material-ui. Fully typed, tree-shakable, and optimized for enterprise-grade forms.",
   "author": "Nishant Kohli",
   "homepage": "https://rhf-mui-components.vercel.app/",

--- a/packages/rhf-mui-components/package.json
+++ b/packages/rhf-mui-components/package.json
@@ -23,8 +23,9 @@
     "tsdown": "^0.21.4"
   },
   "peerDependencies": {
-    "@mui/icons-material": "^5.0.0 || ^6.0.0 || ^7.0.0",
+    "@mui/system": "^5.0.0 || ^6.0.0 || ^7.0.0",
     "@mui/material": "^5.0.0 || ^6.0.0 || ^7.0.0",
+    "@mui/icons-material": "^5.0.0 || ^6.0.0 || ^7.0.0",
     "@mui/x-date-pickers": "^6.0.0 || ^7.0.0 || ^8.0.0",
     "react-hook-form": "^7.0.0"
   },

--- a/packages/rhf-mui-components/package.json
+++ b/packages/rhf-mui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-components",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "description": "A suite of 20+ production-ready react-hook-form components built with material-ui. Fully typed, tree-shakable, and optimized for enterprise-grade forms.",
   "author": "Nishant Kohli",
   "homepage": "https://rhf-mui-components.vercel.app/",

--- a/packages/rhf-mui-components/src/misc/color-picker/index.tsx
+++ b/packages/rhf-mui-components/src/misc/color-picker/index.tsx
@@ -27,7 +27,8 @@ import {
   fieldNameToLabel,
   colorToString,
   useFieldIds,
-  resolveLabelAboveControl
+  resolveLabelAboveControl,
+  resolveRequired
 } from '@/utils';
 import 'react-color-palette/css';
 
@@ -151,19 +152,21 @@ const RHFColorPicker = <T extends FieldValues>({
   ...otherColorPickerProps
 }: RHFColorPickerProps<T>) => {
   const { allLabelsAboveFields } = useContext(RHFMuiConfigContext);
-  const isLabelAboveControl = resolveLabelAboveControl(
-    showLabelAboveFormField,
-    allLabelsAboveFields
-  );
-
   const {
     labelId,
     helperTextId,
     errorId
   } = useFieldIds(fieldName);
+
+  const isLabelAboveControl = resolveLabelAboveControl(
+    showLabelAboveFormField,
+    allLabelsAboveFields
+  );
+  const fieldLabel = label ?? fieldNameToLabel(fieldName);
+  const isFieldRequired = resolveRequired(required, registerOptions?.required);
+
   const [color, setColor] = useColor(value ?? defaultColor);
   const renderHSLView = valueKey === 'hsv';
-  const fieldLabel = label ?? fieldNameToLabel(fieldName);
 
   const getFormattedColor = (color: IColor) =>
     valueKey === 'hex'
@@ -190,7 +193,7 @@ const RHFColorPicker = <T extends FieldValues>({
             <FormLabel
               label={fieldLabel}
               isVisible={isLabelAboveControl}
-              required={required}
+              required={isFieldRequired}
               error={isError}
               disabled={isDisabled}
               formLabelProps={{

--- a/packages/rhf-mui-components/src/misc/phone-input/index.tsx
+++ b/packages/rhf-mui-components/src/misc/phone-input/index.tsx
@@ -5,7 +5,14 @@
 
 'use client';
 
-import { useContext, useMemo, type ReactNode } from 'react';
+import {
+  useContext,
+  useState,
+  useEffect,
+  useMemo,
+  useRef,
+  type ReactNode
+} from 'react';
 import {
   Controller,
   type FieldValues,
@@ -44,9 +51,14 @@ import {
   fieldNameToLabel,
   keepLabelAboveFormField,
   isAboveMuiV5,
-  useFieldIds
+  useFieldIds,
+  resolveRequired
 } from '@/utils';
 import 'react-international-phone/style.css';
+
+const countryMenuWidth = 350;
+const countryMenuLeftOffset = -34;
+const countryMenuViewportGutter = 32;
 
 type PhoneInputChangeReturnValue = {
   phone: string;
@@ -150,6 +162,12 @@ const RHFPhoneInput = <T extends FieldValues>({
     showLabelAboveFormField,
     allLabelsAboveFields
   );
+  const isFieldRequired = resolveRequired(required, registerOptions?.required);
+
+  const [countryMenuLeft, setCountryMenuLeft] = useState(0);
+  const [countryMenuWidthPx, setCountryMenuWidthPx] = useState(countryMenuWidth);
+  const phoneInputRootRef = useRef<HTMLDivElement | null>(null);
+
   const {
     countries,
     hideDropdown,
@@ -158,6 +176,43 @@ const RHFPhoneInput = <T extends FieldValues>({
     ...otherPhoneInputProps
   } = phoneInputProps ?? {};
   const countryOptions = countries ?? defaultCountries;
+
+  const updateCountryMenuLayout = () => {
+    const inputWidth = phoneInputRootRef.current?.offsetWidth ?? 0;
+    const hasViewportRoom
+      = window.innerWidth
+        > countryMenuWidth
+        + Math.abs(countryMenuLeftOffset)
+        + countryMenuViewportGutter;
+
+    /*
+     * The country `Select` sits inside the start adornment, so the menu's
+     * anchor is inset ~|countryMenuLeftOffset|px from the field's left edge.
+     * Shift the menu back by that offset so its left edge aligns with the
+     * field (and, once width is capped below, its right edge too). Applied
+     * whenever the viewport has room — independent of field width, so a narrow
+     * `md={6}` field aligns just like a full-width one. On very small viewports
+     * the shift is skipped to avoid pushing the menu off the left edge.
+     */
+    setCountryMenuLeft(hasViewportRoom ? countryMenuLeftOffset : 0);
+
+    /*
+     * Cap the menu at the field width so a narrow field (e.g. `md={6}`) doesn't
+     * let the fixed 350px menu spill into the adjacent grid column. When the
+     * field is wider than the menu, keep the full `countryMenuWidth`.
+     */
+    setCountryMenuWidthPx(
+      inputWidth > 0 ? Math.min(countryMenuWidth, inputWidth) : countryMenuWidth
+    );
+  };
+
+  useEffect(() => {
+    updateCountryMenuLayout();
+    window.addEventListener('resize', updateCountryMenuLayout);
+    return () => {
+      window.removeEventListener('resize', updateCountryMenuLayout);
+    };
+  }, []);
 
   /**
    * Render preferred countries at the top of the list.
@@ -228,7 +283,7 @@ const RHFPhoneInput = <T extends FieldValues>({
               ? errorId
               : helperTextId
             : undefined,
-          'aria-required': required
+          'aria-required': isFieldRequired
         };
 
         const startAdornment = (
@@ -238,11 +293,17 @@ const RHFPhoneInput = <T extends FieldValues>({
           >
             <Select
               MenuProps={{
+                autoFocus: false,
+                PaperProps: {
+                  sx: {
+                    width: `min(${countryMenuWidthPx}px, calc(100vw - ${countryMenuViewportGutter}px))`,
+                    maxWidth: `calc(100vw - ${countryMenuViewportGutter}px)`,
+                    maxHeight: 300
+                  }
+                },
                 style: {
-                  height: '300px',
-                  width: '360px',
                   top: '10px',
-                  left: '-34px'
+                  left: countryMenuLeft
                 },
                 transformOrigin: {
                   vertical: 'top',
@@ -269,6 +330,7 @@ const RHFPhoneInput = <T extends FieldValues>({
               }}
               value={country.iso2}
               disabled={isDisabled || hideDropdown}
+              onOpen={updateCountryMenuLayout}
               onChange={e => {
                 setCountry(e.target.value as CountryIso2);
               }}
@@ -322,7 +384,7 @@ const RHFPhoneInput = <T extends FieldValues>({
             <FormLabel
               label={fieldLabel}
               isVisible={isLabelAboveFormField}
-              required={required}
+              required={isFieldRequired}
               error={isError}
               disabled={isDisabled}
               formLabelProps={{
@@ -333,6 +395,7 @@ const RHFPhoneInput = <T extends FieldValues>({
             />
             <MuiTextField
               {...otherTextFieldProps}
+              ref={phoneInputRootRef}
               id={fieldId}
               name={rhfFieldName}
               inputRef={ref => {
@@ -353,7 +416,7 @@ const RHFPhoneInput = <T extends FieldValues>({
               label={
                 !isLabelAboveFormField
                   ? (
-                    <FormLabelText label={fieldLabel} required={required} />
+                    <FormLabelText label={fieldLabel} required={isFieldRequired} />
                   )
                   : undefined
               }

--- a/packages/rhf-mui-components/src/misc/phone-input/index.tsx
+++ b/packages/rhf-mui-components/src/misc/phone-input/index.tsx
@@ -57,7 +57,12 @@ import {
 import 'react-international-phone/style.css';
 
 const countryMenuWidth = 350;
-const countryMenuLeftOffset = -34;
+/*
+ * Defensive-only: the menu is anchored to the field itself and capped at the
+ * field's own width, so it can never overflow the field's box. This gutter
+ * only guards the (rare) case where the field's own layout already pushes it
+ * flush against the viewport edge, e.g. a full-width field with no side margin.
+ */
 const countryMenuViewportGutter = 32;
 
 type PhoneInputChangeReturnValue = {
@@ -164,8 +169,8 @@ const RHFPhoneInput = <T extends FieldValues>({
   );
   const isFieldRequired = resolveRequired(required, registerOptions?.required);
 
-  const [countryMenuLeft, setCountryMenuLeft] = useState(0);
   const [countryMenuWidthPx, setCountryMenuWidthPx] = useState(countryMenuWidth);
+  const [countryMenuAnchorEl, setCountryMenuAnchorEl] = useState<HTMLDivElement | null>(null);
   const phoneInputRootRef = useRef<HTMLDivElement | null>(null);
 
   const {
@@ -179,27 +184,13 @@ const RHFPhoneInput = <T extends FieldValues>({
 
   const updateCountryMenuLayout = () => {
     const inputWidth = phoneInputRootRef.current?.offsetWidth ?? 0;
-    const hasViewportRoom
-      = window.innerWidth
-        > countryMenuWidth
-        + Math.abs(countryMenuLeftOffset)
-        + countryMenuViewportGutter;
-
-    /*
-     * The country `Select` sits inside the start adornment, so the menu's
-     * anchor is inset ~|countryMenuLeftOffset|px from the field's left edge.
-     * Shift the menu back by that offset so its left edge aligns with the
-     * field (and, once width is capped below, its right edge too). Applied
-     * whenever the viewport has room — independent of field width, so a narrow
-     * `md={6}` field aligns just like a full-width one. On very small viewports
-     * the shift is skipped to avoid pushing the menu off the left edge.
-     */
-    setCountryMenuLeft(hasViewportRoom ? countryMenuLeftOffset : 0);
 
     /*
      * Cap the menu at the field width so a narrow field (e.g. `md={6}`) doesn't
      * let the fixed 350px menu spill into the adjacent grid column. When the
-     * field is wider than the menu, keep the full `countryMenuWidth`.
+     * field is wider than the menu, keep the full `countryMenuWidth`. The menu
+     * is anchored directly to the field itself (see `anchorEl` below), so its
+     * right edge never exceeds the field's own right edge on any viewport width.
      */
     setCountryMenuWidthPx(
       inputWidth > 0 ? Math.min(countryMenuWidth, inputWidth) : countryMenuWidth
@@ -207,6 +198,7 @@ const RHFPhoneInput = <T extends FieldValues>({
   };
 
   useEffect(() => {
+    setCountryMenuAnchorEl(phoneInputRootRef.current);
     updateCountryMenuLayout();
     window.addEventListener('resize', updateCountryMenuLayout);
     return () => {
@@ -294,20 +286,22 @@ const RHFPhoneInput = <T extends FieldValues>({
             <Select
               MenuProps={{
                 autoFocus: false,
-                PaperProps: {
-                  sx: {
-                    width: `min(${countryMenuWidthPx}px, calc(100vw - ${countryMenuViewportGutter}px))`,
-                    maxWidth: `calc(100vw - ${countryMenuViewportGutter}px)`,
-                    maxHeight: 300
-                  }
-                },
-                style: {
-                  top: '10px',
-                  left: countryMenuLeft
+                ...(countryMenuAnchorEl ? { anchorEl: countryMenuAnchorEl } : {}),
+                anchorOrigin: {
+                  vertical: 'bottom',
+                  horizontal: 'left'
                 },
                 transformOrigin: {
                   vertical: 'top',
                   horizontal: 'left'
+                },
+                PaperProps: {
+                  sx: {
+                    mt: '4px',
+                    width: `min(${countryMenuWidthPx}px, calc(100vw - ${countryMenuViewportGutter}px))`,
+                    maxWidth: `calc(100vw - ${countryMenuViewportGutter}px)`,
+                    maxHeight: 300
+                  }
                 }
               }}
               sx={{

--- a/packages/rhf-mui-components/src/misc/rich-text-editor/index.tsx
+++ b/packages/rhf-mui-components/src/misc/rich-text-editor/index.tsx
@@ -20,7 +20,7 @@ import {
   type FormHelperTextProps
 } from '@/common';
 import { RHFMuiConfigContext } from '@/config/ConfigProvider';
-import { fieldNameToLabel, useFieldIds, resolveLabelAboveControl } from '@/utils';
+import { fieldNameToLabel, useFieldIds, resolveLabelAboveControl, resolveRequired } from '@/utils';
 import { DefaultEditorConfig } from './config';
 import 'ckeditor5/ckeditor5.css';
 
@@ -150,6 +150,7 @@ const RHFRichTextEditor = <T extends FieldValues>({
     showLabelAboveFormField,
     allLabelsAboveFields
   );
+  const isFieldRequired = resolveRequired(required, registerOptions?.required);
 
   return (
     <Controller
@@ -174,7 +175,7 @@ const RHFRichTextEditor = <T extends FieldValues>({
             <FormLabel
               label={fieldLabel}
               isVisible={isLabelAboveControl}
-              required={required}
+              required={isFieldRequired}
               error={isError}
               disabled={isDisabled}
               formLabelProps={{
@@ -207,7 +208,7 @@ const RHFRichTextEditor = <T extends FieldValues>({
                     : helperTextId
                   : undefined
               }
-              aria-required={required}
+              aria-required={isFieldRequired}
               onFocus={onFocus}
               onError={onError}
               disabled={isDisabled}

--- a/packages/rhf-mui-components/src/mui-pickers/date-time/index.tsx
+++ b/packages/rhf-mui-components/src/mui-pickers/date-time/index.tsx
@@ -29,6 +29,7 @@ import {
   fieldNameToLabel,
   generateDateAdapterErrMsg,
   keepLabelAboveFormField,
+  resolveRequired,
   useFieldIds
 } from '@/utils';
 
@@ -136,6 +137,8 @@ const RHFDateTimePicker = <T extends FieldValues>({
     allLabelsAboveFields
   );
   const fieldLabel = label ?? fieldNameToLabel(fieldName);
+  const isFieldRequired = resolveRequired(required, registerOptions?.required);
+
   return (
     <Controller
       name={fieldName}
@@ -161,7 +164,7 @@ const RHFDateTimePicker = <T extends FieldValues>({
               <FormLabel
                 label={fieldLabel}
                 isVisible={isLabelAboveFormField}
-                required={required}
+                required={isFieldRequired}
                 error={isError}
                 disabled={isDisabled}
                 formLabelProps={{
@@ -191,7 +194,7 @@ const RHFDateTimePicker = <T extends FieldValues>({
                 label={
                   !isLabelAboveFormField
                     ? (
-                      <FormLabelText label={fieldLabel} required={required} />
+                      <FormLabelText label={fieldLabel} required={isFieldRequired} />
                     )
                     : undefined
                 }
@@ -212,7 +215,7 @@ const RHFDateTimePicker = <T extends FieldValues>({
                           ? errorId
                           : helperTextId
                         : undefined,
-                      'aria-required': required || undefined
+                      'aria-required': isFieldRequired
                     },
                   }
                 }}

--- a/packages/rhf-mui-components/src/mui-pickers/date/index.tsx
+++ b/packages/rhf-mui-components/src/mui-pickers/date/index.tsx
@@ -29,6 +29,7 @@ import {
   fieldNameToLabel,
   generateDateAdapterErrMsg,
   keepLabelAboveFormField,
+  resolveRequired,
   useFieldIds,
 } from '@/utils';
 
@@ -135,6 +136,8 @@ const RHFDatePicker = <T extends FieldValues>({
     allLabelsAboveFields
   );
   const fieldLabel = label ?? fieldNameToLabel(fieldName);
+  const isFieldRequired = resolveRequired(required, registerOptions?.required);
+
   return (
     <Controller
       name={fieldName}
@@ -160,7 +163,7 @@ const RHFDatePicker = <T extends FieldValues>({
               <FormLabel
                 label={fieldLabel}
                 isVisible={isLabelAboveFormField}
-                required={required}
+                required={isFieldRequired}
                 error={isError}
                 disabled={isDisabled}
                 formLabelProps={{
@@ -195,7 +198,7 @@ const RHFDatePicker = <T extends FieldValues>({
                 label={
                   !isLabelAboveFormField
                     ? (
-                      <FormLabelText label={fieldLabel} required={required} />
+                      <FormLabelText label={fieldLabel} required={isFieldRequired} />
                     )
                     : undefined
                 }
@@ -216,7 +219,7 @@ const RHFDatePicker = <T extends FieldValues>({
                           ? errorId
                           : helperTextId
                         : undefined,
-                      'aria-required': required || undefined
+                      'aria-required': isFieldRequired
                     },
                   },
                 }}

--- a/packages/rhf-mui-components/src/mui-pickers/time/index.tsx
+++ b/packages/rhf-mui-components/src/mui-pickers/time/index.tsx
@@ -29,6 +29,7 @@ import {
   fieldNameToLabel,
   generateDateAdapterErrMsg,
   keepLabelAboveFormField,
+  resolveRequired,
   useFieldIds
 } from '@/utils';
 
@@ -136,6 +137,8 @@ const RHFTimePicker = <T extends FieldValues>({
     allLabelsAboveFields
   );
   const fieldLabel = label ?? fieldNameToLabel(fieldName);
+  const isFieldRequired = resolveRequired(required, registerOptions?.required);
+
   return (
     <Controller
       name={fieldName}
@@ -161,7 +164,7 @@ const RHFTimePicker = <T extends FieldValues>({
               <FormLabel
                 label={fieldLabel}
                 isVisible={isLabelAboveFormField}
-                required={required}
+                required={isFieldRequired}
                 error={isError}
                 disabled={isDisabled}
                 formLabelProps={{
@@ -191,7 +194,7 @@ const RHFTimePicker = <T extends FieldValues>({
                 label={
                   !isLabelAboveFormField
                     ? (
-                      <FormLabelText label={fieldLabel} required={required} />
+                      <FormLabelText label={fieldLabel} required={isFieldRequired} />
                     )
                     : undefined
                 }
@@ -212,7 +215,7 @@ const RHFTimePicker = <T extends FieldValues>({
                           ? errorId
                           : helperTextId
                         : undefined,
-                      'aria-required': required || undefined
+                      'aria-required': isFieldRequired
                     },
                   }
                 }}

--- a/packages/rhf-mui-components/src/mui/autocomplete-object/index.tsx
+++ b/packages/rhf-mui-components/src/mui/autocomplete-object/index.tsx
@@ -39,7 +39,8 @@ import {
   fieldNameToLabel,
   isAboveMuiV5,
   useFieldIds,
-  keepLabelAboveFormField
+  keepLabelAboveFormField,
+  resolveRequired
 } from '@/utils';
 
 type OmittedAutocompleteProps<
@@ -227,6 +228,7 @@ const RHFAutocompleteObject = <
     allLabelsAboveFields
   );
   const fieldLabel = label ?? fieldNameToLabel(fieldName);
+  const isFieldRequired = resolveRequired(required, registerOptions?.required);
 
   const renderOptionLabel = useCallback(
     (option: Option): string => {
@@ -264,7 +266,7 @@ const RHFAutocompleteObject = <
             <FormLabel
               label={fieldLabel}
               isVisible={isLabelAboveFormField}
-              required={required}
+              required={isFieldRequired}
               error={isError}
               disabled={isDisabled}
               formLabelProps={{
@@ -339,7 +341,7 @@ const RHFAutocompleteObject = <
                 } = textFieldProps ?? {};
                 const textFieldInputProps = {
                   ...inputProps,
-                  'aria-required': required,
+                  'aria-required': isFieldRequired,
                   'aria-labelledby': isLabelAboveFormField ? labelId : undefined,
                   'aria-describedby': showHelperTextElement
                     ? (isError ? errorId : helperTextId)
@@ -356,7 +358,7 @@ const RHFAutocompleteObject = <
                     label={
                       !isLabelAboveFormField
                         ? (
-                          <FormLabelText label={fieldLabel} required={required} />
+                          <FormLabelText label={fieldLabel} required={isFieldRequired} />
                         )
                         : undefined
                     }

--- a/packages/rhf-mui-components/src/mui/autocomplete/index.tsx
+++ b/packages/rhf-mui-components/src/mui/autocomplete/index.tsx
@@ -44,7 +44,8 @@ import {
   isKeyValueOption,
   isAboveMuiV5,
   useFieldIds,
-  keepLabelAboveFormField
+  keepLabelAboveFormField,
+  resolveRequired
 } from '@/utils';
 
 type OmittedAutocompleteProps<
@@ -225,6 +226,7 @@ const RHFAutocomplete = <
     allLabelsAboveFields
   );
   const fieldLabel = label ?? fieldNameToLabel(fieldName);
+  const isFieldRequired = resolveRequired(required, registerOptions?.required);
 
   const optionsMap = useMemo(() => {
     if (!valueKey) {
@@ -290,7 +292,7 @@ const RHFAutocomplete = <
             <FormLabel
               label={fieldLabel}
               isVisible={isLabelAboveFormField}
-              required={required}
+              required={isFieldRequired}
               error={isError}
               disabled={isDisabled}
               formLabelProps={{
@@ -374,7 +376,7 @@ const RHFAutocomplete = <
                 } = textFieldProps ?? {};
                 const textFieldInputProps = {
                   ...inputProps,
-                  'aria-required': required,
+                  'aria-required': isFieldRequired,
                   'aria-labelledby': isLabelAboveFormField ? labelId : undefined,
                   'aria-describedby': showHelperTextElement
                     ? (isError ? errorId : helperTextId)
@@ -391,7 +393,7 @@ const RHFAutocomplete = <
                     label={
                       !isLabelAboveFormField
                         ? (
-                          <FormLabelText label={fieldLabel} required={required} />
+                          <FormLabelText label={fieldLabel} required={isFieldRequired} />
                         )
                         : undefined
                     }

--- a/packages/rhf-mui-components/src/mui/checkbox-group/index.tsx
+++ b/packages/rhf-mui-components/src/mui/checkbox-group/index.tsx
@@ -34,7 +34,8 @@ import {
   coerceValue,
   getOptionValue,
   useFieldIds,
-  resolveLabelAboveControl
+  resolveLabelAboveControl,
+  resolveRequired
 } from '@/utils';
 
 export type RHFCheckboxGroupProps<
@@ -180,6 +181,7 @@ const RHFCheckboxGroup = <
     allLabelsAboveFields
   );
   const fieldLabel = label ?? fieldNameToLabel(fieldName);
+  const isFieldRequired = resolveRequired(required, registerOptions?.required);
 
   const { sx, ...otherFormControlLabelProps } = formControlLabelProps ?? {};
   const appliedFormControlLabelSx = {
@@ -246,7 +248,7 @@ const RHFCheckboxGroup = <
               <FormLabel
                 label={fieldLabel}
                 isVisible={isLabelAboveControl}
-                required={required}
+                required={isFieldRequired}
                 error={isError}
                 disabled={isDisabled}
                 formLabelProps={{

--- a/packages/rhf-mui-components/src/mui/checkbox/index.tsx
+++ b/packages/rhf-mui-components/src/mui/checkbox/index.tsx
@@ -22,7 +22,7 @@ import {
   type CheckboxProps
 } from '@/common';
 import { RHFMuiConfigContext } from '@/config/ConfigProvider';
-import { fieldNameToLabel, useFieldIds } from '@/utils';
+import { fieldNameToLabel, resolveRequired, useFieldIds } from '@/utils';
 
 export type RHFCheckboxProps<T extends FieldValues> = {
   /**
@@ -79,6 +79,7 @@ const RHFCheckbox = <T extends FieldValues>({
   control,
   registerOptions,
   onValueChange,
+  required,
   disabled: muiDisabled,
   label,
   formControlLabelProps,
@@ -98,6 +99,7 @@ const RHFCheckbox = <T extends FieldValues>({
 
   const { defaultFormControlLabelSx } = useContext(RHFMuiConfigContext);
   const fieldLabel = label ?? fieldNameToLabel(fieldName);
+  const isFieldRequired = resolveRequired(required, registerOptions?.required);
 
   const { sx, ...otherFormControlLabelProps } = formControlLabelProps ?? {};
   const appliedFormControlLabelSx = {
@@ -105,6 +107,7 @@ const RHFCheckbox = <T extends FieldValues>({
     ...sx,
   };
   const { input: slotPropsInput, ...otherSlotProps } = muiSlotProps ?? {};
+
   return (
     <Fragment>
       <Controller
@@ -135,15 +138,6 @@ const RHFCheckbox = <T extends FieldValues>({
                     id={fieldId}
                     name={rhfFieldName}
                     checked={Boolean(rhfValue)}
-                    disabled={isDisabled}
-                    aria-describedby={
-                      showHelperTextElement
-                        ? isError
-                          ? errorId
-                          : helperTextId
-                        : undefined
-                    }
-                    aria-invalid={isError || undefined}
                     onChange={(event, checked) => {
                       rhfOnChange(checked);
                       onValueChange?.(checked, event);
@@ -152,6 +146,17 @@ const RHFCheckbox = <T extends FieldValues>({
                       rhfOnBlur();
                       onBlur?.(blurEvent);
                     }}
+                    required={required}
+                    disabled={isDisabled}
+                    aria-describedby={
+                      showHelperTextElement
+                        ? isError
+                          ? errorId
+                          : helperTextId
+                        : undefined
+                    }
+                    aria-required={isFieldRequired}
+                    aria-invalid={isError || undefined}
                     slotProps={{
                       ...otherSlotProps,
                       input: {

--- a/packages/rhf-mui-components/src/mui/country-select/index.tsx
+++ b/packages/rhf-mui-components/src/mui/country-select/index.tsx
@@ -42,6 +42,7 @@ import {
   fieldNameToLabel,
   isAboveMuiV5,
   keepLabelAboveFormField,
+  resolveRequired,
   useFieldIds
 } from '@/utils';
 import CountryMenuItem from './CountryMenuItem';
@@ -233,6 +234,7 @@ const RHFCountrySelect = <
     allLabelsAboveFields
   );
   const fieldLabel = label ?? fieldNameToLabel(fieldName);
+  const isFieldRequired = resolveRequired(required, registerOptions?.required);
 
   const countryOptions = countries ?? countryList;
   const countrySelectOptions = useMemo(() => {
@@ -299,7 +301,7 @@ const RHFCountrySelect = <
             <FormLabel
               label={fieldLabel}
               isVisible={isLabelAboveFormField}
-              required={required}
+              required={isFieldRequired}
               error={isError}
               disabled={isDisabled}
               formLabelProps={{
@@ -356,7 +358,7 @@ const RHFCountrySelect = <
                 } = textFieldProps ?? {};
                 const textFieldInputProps = {
                   ...inputProps,
-                  'aria-required': required,
+                  'aria-required': isFieldRequired,
                   'aria-labelledby': isLabelAboveFormField ? labelId : undefined,
                   'aria-describedby': showHelperTextElement
                     ? (isError ? errorId : helperTextId)
@@ -373,7 +375,7 @@ const RHFCountrySelect = <
                     label={
                       !isLabelAboveFormField
                         ? (
-                          <FormLabelText label={fieldLabel} required={required} />
+                          <FormLabelText label={fieldLabel} required={isFieldRequired} />
                         )
                         : undefined
                     }

--- a/packages/rhf-mui-components/src/mui/file-uploader/index.tsx
+++ b/packages/rhf-mui-components/src/mui/file-uploader/index.tsx
@@ -306,6 +306,7 @@ const RHFFileUploader = <
                 ? (isError ? errorId : helperTextId)
                 : undefined
             }
+            aria-required={isFieldRequired}
             aria-invalid={isError}
           />
         );

--- a/packages/rhf-mui-components/src/mui/file-uploader/index.tsx
+++ b/packages/rhf-mui-components/src/mui/file-uploader/index.tsx
@@ -4,7 +4,8 @@ import {
   useContext,
   Fragment,
   type ReactNode,
-  type ChangeEvent
+  type ChangeEvent,
+  type FocusEvent
 } from 'react';
 import {
   Controller,
@@ -135,6 +136,10 @@ export type RHFFileUploaderProps<
     rejectedFiles: File[],
   ) => void;
   /**
+   * Called when the hidden file input loses focus.
+   */
+  onBlur?: (event: FocusEvent<HTMLInputElement, Element>) => void;
+  /**
    * Label content shown for the field. Defaults to a label generated from `fieldName`.
    */
   label?: ReactNode;
@@ -186,6 +191,7 @@ const RHFFileUploader = <
   renderUploadButton,
   renderFileItem,
   onValueChange,
+  onBlur,
   disabled: muiDisabled,
   onUploadError,
   label,
@@ -289,7 +295,10 @@ const RHFFileUploader = <
             accept={accept}
             multiple={multiple}
             onChange={handleFileChange}
-            onBlur={rhfOnBlur}
+            onBlur={event => {
+              rhfOnBlur();
+              onBlur?.(event);
+            }}
             disabled={isDisabled}
             aria-labelledby={isLabelAboveFormField ? labelId : undefined}
             aria-describedby={

--- a/packages/rhf-mui-components/src/mui/file-uploader/index.tsx
+++ b/packages/rhf-mui-components/src/mui/file-uploader/index.tsx
@@ -25,6 +25,7 @@ import { RHFMuiConfigContext } from '@/config/ConfigProvider';
 import {
   fieldNameToLabel,
   keepLabelAboveFormField,
+  resolveRequired,
   useFieldIds,
   validateFileList
 } from '@/utils';
@@ -210,6 +211,7 @@ const RHFFileUploader = <
     showLabelAboveFormField,
     allLabelsAboveFields
   );
+  const isFieldRequired = resolveRequired(required, registerOptions?.required);
 
   return (
     <Controller
@@ -308,7 +310,7 @@ const RHFFileUploader = <
             <FormLabel
               label={fieldLabel}
               isVisible={isLabelAboveFormField}
-              required={required}
+              required={isFieldRequired}
               error={isError}
               disabled={isDisabled}
               formLabelProps={{

--- a/packages/rhf-mui-components/src/mui/multi-autocomplete-object/index.tsx
+++ b/packages/rhf-mui-components/src/mui/multi-autocomplete-object/index.tsx
@@ -44,7 +44,8 @@ import {
   isKeyValueOption,
   isAboveMuiV5,
   useFieldIds,
-  keepLabelAboveFormField
+  keepLabelAboveFormField,
+  resolveRequired
 } from '@/utils';
 
 type MultiAutoCompleteProps<
@@ -234,6 +235,7 @@ const RHFMultiAutocompleteObject = <
     allLabelsAboveFields
   );
   const fieldLabel = label ?? fieldNameToLabel(fieldName);
+  const isFieldRequired = resolveRequired(required, registerOptions?.required);
 
   const { sx, ...otherFormControlLabelProps } = formControlLabelProps ?? {};
   const appliedFormControlLabelSx = {
@@ -320,7 +322,7 @@ const RHFMultiAutocompleteObject = <
             <FormLabel
               label={fieldLabel}
               isVisible={isLabelAboveFormField}
-              required={required}
+              required={isFieldRequired}
               error={isError}
               disabled={isDisabled}
               formLabelProps={{
@@ -400,7 +402,7 @@ const RHFMultiAutocompleteObject = <
                 } = textFieldProps ?? {};
                 const textFieldInputProps = {
                   ...inputProps,
-                  'aria-required': required,
+                  'aria-required': isFieldRequired,
                   'aria-labelledby': isLabelAboveFormField ? labelId : undefined,
                   'aria-describedby': showHelperTextElement
                     ? (isError ? errorId : helperTextId)
@@ -422,7 +424,7 @@ const RHFMultiAutocompleteObject = <
                     label={
                       !isLabelAboveFormField
                         ? (
-                          <FormLabelText label={fieldLabel} required={required} />
+                          <FormLabelText label={fieldLabel} required={isFieldRequired} />
                         )
                         : undefined
                     }

--- a/packages/rhf-mui-components/src/mui/multi-autocomplete/index.tsx
+++ b/packages/rhf-mui-components/src/mui/multi-autocomplete/index.tsx
@@ -44,7 +44,8 @@ import {
   isKeyValueOption,
   isAboveMuiV5,
   useFieldIds,
-  keepLabelAboveFormField
+  keepLabelAboveFormField,
+  resolveRequired
 } from '@/utils';
 
 type MultiAutoCompleteProps<
@@ -237,6 +238,7 @@ const RHFMultiAutocomplete = <
     allLabelsAboveFields
   );
   const fieldLabel = label ?? fieldNameToLabel(fieldName);
+  const isFieldRequired = resolveRequired(required, registerOptions?.required);
 
   const { sx, ...otherFormControlLabelProps } = formControlLabelProps ?? {};
   const appliedFormControlLabelSx = {
@@ -335,7 +337,7 @@ const RHFMultiAutocomplete = <
             <FormLabel
               label={fieldLabel}
               isVisible={isLabelAboveFormField}
-              required={required}
+              required={isFieldRequired}
               error={isError}
               disabled={isDisabled}
               formLabelProps={{
@@ -420,7 +422,7 @@ const RHFMultiAutocomplete = <
                 } = textFieldProps ?? {};
                 const textFieldInputProps = {
                   ...inputProps,
-                  'aria-required': required,
+                  'aria-required': isFieldRequired,
                   'aria-labelledby': isLabelAboveFormField ? labelId : undefined,
                   'aria-describedby': showHelperTextElement
                     ? (isError ? errorId : helperTextId)
@@ -442,7 +444,7 @@ const RHFMultiAutocomplete = <
                     label={
                       !isLabelAboveFormField
                         ? (
-                          <FormLabelText label={fieldLabel} required={required} />
+                          <FormLabelText label={fieldLabel} required={isFieldRequired} />
                         )
                         : undefined
                     }

--- a/packages/rhf-mui-components/src/mui/native-select/index.tsx
+++ b/packages/rhf-mui-components/src/mui/native-select/index.tsx
@@ -25,7 +25,8 @@ import {
   isKeyValueOption,
   normalizeSelectValue,
   useFieldIds,
-  resolveLabelAboveControl
+  resolveLabelAboveControl,
+  resolveRequired
 } from '@/utils';
 
 type InputNativeSelectProps = Omit<
@@ -158,6 +159,7 @@ const RHFNativeSelect = <
     showLabelAboveFormField,
     allLabelsAboveFields
   );
+  const isFieldRequired = resolveRequired(required, registerOptions?.required);
 
   return (
     <Controller
@@ -183,7 +185,7 @@ const RHFNativeSelect = <
             <FormLabel
               label={fieldLabel}
               isVisible={isLabelAboveControl}
-              required={required}
+              required={isFieldRequired}
               error={isError}
               disabled={isDisabled}
               formLabelProps={{
@@ -197,7 +199,7 @@ const RHFNativeSelect = <
               id={fieldId}
               name={rhfFieldName}
               autoComplete={autoComplete}
-              aria-required={required}
+              aria-required={isFieldRequired}
               aria-describedby={
                 showHelperTextElement
                   ? (isError ? errorId : helperTextId)
@@ -228,7 +230,7 @@ const RHFNativeSelect = <
                 }
               }}
             >
-              <option value="" disabled={required}>
+              <option value="" disabled={isFieldRequired}>
                 {blankOptionText}
               </option>
               {options.map(option => {

--- a/packages/rhf-mui-components/src/mui/number-input/index.tsx
+++ b/packages/rhf-mui-components/src/mui/number-input/index.tsx
@@ -24,6 +24,7 @@ import {
   fieldNameToLabel,
   isAboveMuiV5,
   keepLabelAboveFormField,
+  resolveRequired,
   useFieldIds
 } from '@/utils';
 
@@ -116,6 +117,8 @@ const RHFNumberInput = <T extends FieldValues>({
     allLabelsAboveFields
   );
   const fieldLabel = label ?? fieldNameToLabel(fieldName);
+  const isFieldRequired = resolveRequired(required, registerOptions?.required);
+
   return (
     <Controller
       name={fieldName}
@@ -142,7 +145,7 @@ const RHFNumberInput = <T extends FieldValues>({
               ? errorId
               : helperTextId
             : undefined,
-          'aria-required': required
+          'aria-required': isFieldRequired
         };
 
         return (
@@ -150,7 +153,7 @@ const RHFNumberInput = <T extends FieldValues>({
             <FormLabel
               label={fieldLabel}
               isVisible={isLabelAboveFormField}
-              required={required}
+              required={isFieldRequired}
               error={isError}
               disabled={isDisabled}
               formLabelProps={{
@@ -169,7 +172,7 @@ const RHFNumberInput = <T extends FieldValues>({
               label={
                 !isLabelAboveFormField
                   ? (
-                    <FormLabelText label={fieldLabel} required={required} />
+                    <FormLabelText label={fieldLabel} required={isFieldRequired} />
                   )
                   : undefined
               }

--- a/packages/rhf-mui-components/src/mui/password-input/index.tsx
+++ b/packages/rhf-mui-components/src/mui/password-input/index.tsx
@@ -34,7 +34,8 @@ import {
   fieldNameToLabel,
   keepLabelAboveFormField,
   isAboveMuiV5,
-  useFieldIds
+  useFieldIds,
+  resolveRequired
 } from '@/utils';
 
 type InputPasswordProps = Omit<
@@ -157,6 +158,8 @@ const RHFPasswordInput = <T extends FieldValues>({
   const ShowPasswordIcon = showPasswordIcon ?? <VisibilityOffIcon />;
   const HidePasswordIcon = hidePasswordIcon ?? <VisibilityIcon />;
 
+  const isFieldRequired = resolveRequired(required, registerOptions?.required);
+
   const handleClickShowPassword = () => setShowPassword(show => !show);
   const handleMouseDownPassword = (event: MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
@@ -188,7 +191,7 @@ const RHFPasswordInput = <T extends FieldValues>({
               ? errorId
               : helperTextId
             : undefined,
-          'aria-required': required,
+          'aria-required': isFieldRequired,
           'aria-readonly': readOnly || undefined
         };
 
@@ -212,7 +215,7 @@ const RHFPasswordInput = <T extends FieldValues>({
             <FormLabel
               label={fieldLabel}
               isVisible={isLabelAboveFormField}
-              required={required}
+              required={isFieldRequired}
               error={isError}
               disabled={isDisabled}
               formLabelProps={{
@@ -231,7 +234,7 @@ const RHFPasswordInput = <T extends FieldValues>({
               label={
                 !isLabelAboveFormField
                   ? (
-                    <FormLabelText label={fieldLabel} required={required} />
+                    <FormLabelText label={fieldLabel} required={isFieldRequired} />
                   )
                   : undefined
               }

--- a/packages/rhf-mui-components/src/mui/radio-group/index.tsx
+++ b/packages/rhf-mui-components/src/mui/radio-group/index.tsx
@@ -29,7 +29,8 @@ import {
   normalizeSelectValue,
   getOptionValue,
   useFieldIds,
-  resolveLabelAboveControl
+  resolveLabelAboveControl,
+  resolveRequired
 } from '@/utils';
 
 type RadioGroupInputProps = Omit<
@@ -171,6 +172,8 @@ const RHFRadioGroup = <
     showLabelAboveFormField,
     allLabelsAboveFields
   );
+  const isFieldRequired = resolveRequired(required, registerOptions?.required);
+
   const { sx, ...otherFormControlLabelProps } = formControlLabelProps ?? {};
   const appliedFormControlLabelSx = {
     ...defaultFormControlLabelSx,
@@ -199,7 +202,7 @@ const RHFRadioGroup = <
             <FormLabel
               label={fieldLabel}
               isVisible={isLabelAboveControl}
-              required={required}
+              required={isFieldRequired}
               error={isError}
               disabled={isDisabled}
               formLabelProps={{
@@ -229,7 +232,7 @@ const RHFRadioGroup = <
                 rhfOnBlur();
                 onBlur?.(blurEvent);
               }}
-              aria-required={required || undefined}
+              aria-required={isFieldRequired}
               aria-labelledby={isLabelAboveControl ? labelId : undefined}
               aria-describedby={
                 showHelperTextElement

--- a/packages/rhf-mui-components/src/mui/rating/index.tsx
+++ b/packages/rhf-mui-components/src/mui/rating/index.tsx
@@ -17,7 +17,7 @@ import {
   type FormHelperTextProps
 } from '@/common';
 import { RHFMuiConfigContext } from '@/config/ConfigProvider';
-import { fieldNameToLabel, useFieldIds, resolveLabelAboveControl } from '@/utils';
+import { fieldNameToLabel, useFieldIds, resolveLabelAboveControl, resolveRequired } from '@/utils';
 
 type InputRatingProps = Omit<
   RatingProps,
@@ -115,6 +115,8 @@ const RHFRating = <T extends FieldValues>({
     showLabelAboveFormField,
     allLabelsAboveFields
   );
+  const isFieldRequired = resolveRequired(required, registerOptions?.required);
+
   return (
     <Controller
       name={fieldName}
@@ -142,7 +144,7 @@ const RHFRating = <T extends FieldValues>({
             <FormLabel
               label={fieldLabel}
               isVisible={isLabelAboveControl}
-              required={required}
+              required={isFieldRequired}
               error={isError}
               disabled={isDisabled}
               formLabelProps={{

--- a/packages/rhf-mui-components/src/mui/rating/index.tsx
+++ b/packages/rhf-mui-components/src/mui/rating/index.tsx
@@ -167,6 +167,7 @@ const RHFRating = <T extends FieldValues>({
                 rhfOnBlur();
                 onBlur?.(blurEvent);
               }}
+              aria-required={isFieldRequired}
               aria-labelledby={isLabelAboveControl ? labelId : undefined}
               aria-describedby={
                 showHelperTextElement

--- a/packages/rhf-mui-components/src/mui/select/index.tsx
+++ b/packages/rhf-mui-components/src/mui/select/index.tsx
@@ -32,6 +32,7 @@ import {
   normalizeSelectValue,
   useFieldIds,
   getDisplayLabelForSelectValue,
+  resolveRequired,
 } from '@/utils';
 
 type SelectValue<Value, Multiple extends boolean>
@@ -189,10 +190,12 @@ const RHFSelect = <
     showLabelAboveFormField,
     allLabelsAboveFields
   );
+  const isFieldRequired = resolveRequired(required, registerOptions?.required);
+
   const fieldLabelText = fieldNameToLabel(fieldName);
   const fieldLabel = label ?? fieldLabelText;
   const SelectFormLabel = (
-    <FormLabelText label={fieldLabel} required={required} />
+    <FormLabelText label={fieldLabel} required={isFieldRequired} />
   );
 
   return (
@@ -228,7 +231,7 @@ const RHFSelect = <
             <FormLabel
               label={fieldLabel}
               isVisible={isLabelAboveFormField}
-              required={required}
+              required={isFieldRequired}
               error={isError}
               disabled={isDisabled}
               formLabelProps={{
@@ -249,7 +252,7 @@ const RHFSelect = <
                 name={rhfFieldName}
                 autoComplete={autoComplete}
                 labelId={selectLabelId}
-                aria-required={required}
+                aria-required={isFieldRequired}
                 aria-describedby={
                   showHelperTextElement
                     ? (isError ? errorId : helperTextId)
@@ -322,7 +325,7 @@ const RHFSelect = <
                 }}
               >
                 {showDefaultOption && (
-                  <MenuItem value="" disabled={required}>
+                  <MenuItem value="" disabled={isFieldRequired}>
                     {defaultOptionText ?? `Select ${fieldLabelText}`}
                   </MenuItem>
                 )}

--- a/packages/rhf-mui-components/src/mui/slider/index.tsx
+++ b/packages/rhf-mui-components/src/mui/slider/index.tsx
@@ -176,6 +176,7 @@ const RHFSlider = <
                 rhfOnBlur();
                 onBlur?.(blurEvent);
               }}
+              aria-required={isFieldRequired}
               aria-labelledby={isLabelAboveControl ? labelId : undefined}
               aria-describedby={
                 showHelperTextElement

--- a/packages/rhf-mui-components/src/mui/slider/index.tsx
+++ b/packages/rhf-mui-components/src/mui/slider/index.tsx
@@ -17,7 +17,7 @@ import {
   type FormHelperTextProps
 } from '@/common';
 import { RHFMuiConfigContext } from '@/config/ConfigProvider';
-import { fieldNameToLabel, useFieldIds, resolveLabelAboveControl } from '@/utils';
+import { fieldNameToLabel, useFieldIds, resolveLabelAboveControl, resolveRequired } from '@/utils';
 
 type SliderInputProps = Omit<
   SliderProps,
@@ -129,6 +129,8 @@ const RHFSlider = <
     showLabelAboveFormField,
     allLabelsAboveFields
   );
+  const isFieldRequired = resolveRequired(required, registerOptions?.required);
+
   return (
     <Controller
       name={fieldName}
@@ -152,7 +154,7 @@ const RHFSlider = <
             <FormLabel
               label={fieldLabel}
               isVisible={isLabelAboveControl}
-              required={required}
+              required={isFieldRequired}
               error={isError}
               disabled={isDisabled}
               formLabelProps={{

--- a/packages/rhf-mui-components/src/mui/switch/index.tsx
+++ b/packages/rhf-mui-components/src/mui/switch/index.tsx
@@ -21,7 +21,7 @@ import {
   type FormHelperTextProps
 } from '@/common';
 import { RHFMuiConfigContext } from '@/config/ConfigProvider';
-import { fieldNameToLabel, useFieldIds } from '@/utils';
+import { fieldNameToLabel, resolveRequired, useFieldIds } from '@/utils';
 
 export type RHFSwitchProps<T extends FieldValues> = {
   /**
@@ -78,6 +78,7 @@ const RHFSwitch = <T extends FieldValues>({
   control,
   registerOptions,
   onValueChange,
+  required,
   disabled: muiDisabled,
   label,
   formControlLabelProps,
@@ -97,6 +98,8 @@ const RHFSwitch = <T extends FieldValues>({
 
   const fieldLabel = label ?? fieldNameToLabel(fieldName);
   const { defaultFormControlLabelSx } = useContext(RHFMuiConfigContext);
+  const isFieldRequired = resolveRequired(required, registerOptions?.required);
+
   const { sx, ...otherFormControlLabelProps } = formControlLabelProps ?? {};
   const appliedFormControlLabelSx = {
     ...defaultFormControlLabelSx,
@@ -140,6 +143,8 @@ const RHFSwitch = <T extends FieldValues>({
                     rhfOnBlur();
                     onBlur?.(blurEvent);
                   }}
+                  required={required}
+                  aria-required={isFieldRequired}
                   aria-describedby={
                     showHelperTextElement
                       ? isError

--- a/packages/rhf-mui-components/src/mui/tags-input/index.tsx
+++ b/packages/rhf-mui-components/src/mui/tags-input/index.tsx
@@ -35,7 +35,8 @@ import {
   keepLabelAboveFormField,
   isAboveMuiV5,
   fieldNameToId,
-  useFieldIds
+  useFieldIds,
+  resolveRequired
 } from '@/utils';
 
 type TextFieldInputProps = Omit<
@@ -159,6 +160,7 @@ const RHFTagsInput = <T extends FieldValues>({
     allLabelsAboveFields
   );
   const fieldLabel = label ?? fieldNameToLabel(fieldName);
+  const isFieldRequired = resolveRequired(required, registerOptions?.required);
 
   /**
    * Similar to MuiAutocomplete, if limitTags = -1, show all the
@@ -262,7 +264,7 @@ const RHFTagsInput = <T extends FieldValues>({
               ? errorId
               : helperTextId
             : undefined,
-          'aria-required': required
+          'aria-required': isFieldRequired
         };
 
         const hideInput = isDisabled && rhfValue.length > 0;
@@ -322,7 +324,7 @@ const RHFTagsInput = <T extends FieldValues>({
             <FormLabel
               label={fieldLabel}
               isVisible={isLabelAboveFormField}
-              required={required}
+              required={isFieldRequired}
               error={isError}
               disabled={isDisabled}
               formLabelProps={{
@@ -340,7 +342,7 @@ const RHFTagsInput = <T extends FieldValues>({
               label={
                 !isLabelAboveFormField
                   ? (
-                    <FormLabelText label={fieldLabel} required={required} />
+                    <FormLabelText label={fieldLabel} required={isFieldRequired} />
                   )
                   : undefined
               }

--- a/packages/rhf-mui-components/src/mui/textfield/index.tsx
+++ b/packages/rhf-mui-components/src/mui/textfield/index.tsx
@@ -23,6 +23,7 @@ import {
   fieldNameToLabel,
   isAboveMuiV5,
   keepLabelAboveFormField,
+  resolveRequired,
   useFieldIds
 } from '@/utils';
 
@@ -104,6 +105,8 @@ const RHFTextField = <T extends FieldValues>({
     allLabelsAboveFields
   );
   const fieldLabel = label ?? fieldNameToLabel(fieldName);
+  const isFieldRequired = resolveRequired(required, registerOptions?.required);
+
   return (
     <Controller
       name={fieldName}
@@ -130,7 +133,7 @@ const RHFTextField = <T extends FieldValues>({
               ? errorId
               : helperTextId
             : undefined,
-          'aria-required': required
+          'aria-required': isFieldRequired
         };
 
         return (
@@ -138,7 +141,7 @@ const RHFTextField = <T extends FieldValues>({
             <FormLabel
               label={fieldLabel}
               isVisible={isLabelAboveFormField}
-              required={required}
+              required={isFieldRequired}
               error={isError}
               disabled={isDisabled}
               formLabelProps={{
@@ -156,7 +159,7 @@ const RHFTextField = <T extends FieldValues>({
               label={
                 !isLabelAboveFormField
                   ? (
-                    <FormLabelText label={fieldLabel} required={required} />
+                    <FormLabelText label={fieldLabel} required={isFieldRequired} />
                   )
                   : undefined
               }

--- a/packages/rhf-mui-components/src/utils/control.ts
+++ b/packages/rhf-mui-components/src/utils/control.ts
@@ -1,3 +1,5 @@
+import type { Message, ValidationRule } from 'react-hook-form';
+
 export function keepLabelAboveFormField(
   showLabelAboveFormField?: boolean,
   allLabelsAboveFields?: boolean
@@ -20,4 +22,19 @@ export function resolveLabelAboveControl(
   allLabelsAboveFields?: boolean
 ): boolean {
   return allLabelsAboveFields ?? showLabelAboveFormField ?? true;
+}
+
+/**
+ * Whether a field is required, combining the explicit `required` prop with
+ * RHF's `registerOptions.required` validation rule — a boolean, a message
+ * string (truthy), or a `{ value, message }` object.
+ */
+export function resolveRequired(
+  required: boolean | undefined,
+  registerRequired: Message | ValidationRule<boolean> | undefined
+): boolean {
+  const isRegisterRequired = typeof registerRequired === 'object'
+    ? registerRequired.value
+    : !!registerRequired;
+  return !!required || isRegisterRequired;
 }


### PR DESCRIPTION
## **User description**
### ✨ Enhancements

- Automatically infer the required state from `register.required`, eliminating the need to manually pass the `required` prop.
- Added `@mui/system` to `peerDependencies`.
- Added the `Theme` generic to `SxProps` in `MUIComponentsConfig` for improved type safety and IntelliSense support.
- `RHFFileUploader`: Added `onBlur` prop
- `RHFCheckbox` & `RHFSwitch`: The value of `aria-required` attribute is also determined from RHF's `registerOptions.required` validation.
- Added support for the `aria-required` attribute to `MUIRating` for improved accessibility.

### 🐞 Bug Fixes
- `MUIPhoneInput`: Fixed the country dropdown shifting/misaligning out of place on narrow viewports (< 440px) by anchoring it to the field itself instead of the flag trigger.


___

## **CodeAnt-AI Description**
Infer required fields from React Hook Form rules across all form components

### What Changed
- Form labels, required indicators, accessibility attributes, and select placeholders now reflect `registerOptions.required` without requiring a separate `required` prop.
- Checkboxes and switches expose the resolved required state and continue forwarding value-change and blur callbacks.
- File uploads now provide an `onBlur` callback for the hidden file input.
- Rating controls now expose their required state to assistive technologies.
- The phone country menu stays anchored to the input, fits narrow fields, and avoids overflowing the viewport.
- Package versions, peer dependencies, changelog, and README guidance were updated for version 3.6.0.

### Impact
`✅ Consistent required indicators across form controls`
`✅ Clearer accessibility information for required fields`
`✅ Fewer phone country-menu alignment issues on narrow screens`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
