### PR TITLE
v4.2.2 - Ref forwarding for static date-time pickers

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 >
 > From **v4.2.0** onwards, every component delegates its rendering and core logic to the form-library-agnostic **[@nish1896/mui-components](https://mui-components-docs.vercel.app/)** — the same Material UI components, driven by a plain `value` / `onValueChange` pair instead of RHF bindings.
 >
-> Worth checking out if you ever need these components outside React Hook Form (TanStack Form, Formik or plain React state).
+> Worth checking out if you're building forms with plain React state or any other form library, or need Material UI components without wiring custom UI logic for commonly used components.
 
 ## ✨ Features
 

--- a/apps/rhf-mui-demo/package.json
+++ b/apps/rhf-mui-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-demo",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "private": true,
   "author": "Nishant Kohli",
   "scripts": {

--- a/apps/rhf-mui-docs/package.json
+++ b/apps/rhf-mui-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-docs",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/changelog/v4.md
+++ b/changelog/v4.md
@@ -1,5 +1,16 @@
 # Changelog - v4
 
+## [4.2.2](https://github.com/nishkohli96/rhf-mui-components/tree/v4.2.2)
+
+**Released — 4 August, 2026**
+
+### ✨ Enhancements
+- Updated `@nish1896/mui-components` to **v1.0.5**, which includes a fix for `ref` forwarding in static date and time pickers.
+
+### 🐞 Bug Fixes
+- Added `ref` forwarding support to `RHFStaticDatePicker`, `RHFStaticDateTimePicker` and `RHFStaticTimePicker`. The ref is merged with RHF's field ref and attached to each picker's wrapping container (static pickers have no `<input>` to target), so RHF's focus-on-validation-error behavior now correctly scrolls to and focuses these fields on submit.
+
+
 ## [4.2.1](https://github.com/nishkohli96/rhf-mui-components/tree/v4.2.1)
 
 **Released — 4 August, 2026**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-components-root",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "A suite of 25+ production-ready react-hook-form components built with material-ui. Fully typed, tree-shakable, and optimized for enterprise-grade forms.",
   "author": "Nishant Kohli",
   "private": true,

--- a/packages/rhf-mui-components/README.md
+++ b/packages/rhf-mui-components/README.md
@@ -21,7 +21,7 @@
 >
 > From **v4.2.0** onwards, every component delegates its rendering and core logic to the form-library-agnostic **[@nish1896/mui-components](https://mui-components-docs.vercel.app/)** — the same Material UI components, driven by a plain `value` / `onValueChange` pair instead of RHF bindings.
 >
-> Worth checking out if you ever need these components outside React Hook Form (TanStack Form, Formik or plain React state).
+> Worth checking out if you're building forms with plain React state or any other form library, or need Material UI components without wiring custom UI logic for commonly used components.
 
 ## ✨ Features
 

--- a/packages/rhf-mui-components/package.json
+++ b/packages/rhf-mui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-components",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "A suite of 25+ production-ready react-hook-form components built with material-ui. Fully typed, tree-shakable, and optimized for enterprise-grade forms.",
   "author": "Nishant Kohli",
   "homepage": "https://rhf-mui-components.vercel.app/",
@@ -16,7 +16,7 @@
   "type": "module",
   "sideEffects": false,
   "dependencies": {
-    "@nish1896/mui-components": "^1.0.4"
+    "@nish1896/mui-components": "^1.0.5"
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-core": "43.3.0",
@@ -45,9 +45,9 @@
     "typescript": "^6.0.3"
   },
   "peerDependencies": {
-    "@mui/system": "^6.0.0 || ^7.0.0",
-    "@mui/material": "^6.0.0 || ^7.0.0",
     "@mui/icons-material": "^6.0.0 || ^7.0.0",
+    "@mui/material": "^6.0.0 || ^7.0.0",
+    "@mui/system": "^6.0.0 || ^7.0.0",
     "@mui/x-date-pickers": "^7.0.0 || ^8.0.0",
     "react-hook-form": "^7.0.0"
   },

--- a/packages/rhf-mui-components/src/mui-pickers/date-time/RHFStaticDateTimePicker.tsx
+++ b/packages/rhf-mui-components/src/mui-pickers/date-time/RHFStaticDateTimePicker.tsx
@@ -2,8 +2,10 @@
 
 import {
   useContext,
+  forwardRef,
   type ReactNode,
-  type JSX
+  type JSX,
+  type Ref
 } from 'react';
 import {
   Controller,
@@ -30,6 +32,7 @@ import type { CustomComponentIds } from '@/types';
 import {
   generateDateAdapterErrMsg,
   keepLabelAboveFormField,
+  mergeRefs,
   mergeSx,
   resolveRequired
 } from '@/utils';
@@ -143,29 +146,34 @@ export type RHFStaticDateTimePickerProps<T extends FieldValues> = {
   customIds?: CustomComponentIds;
 } & StaticDateTimePickerInputProps;
 
-const RHFStaticDateTimePicker = <T extends FieldValues>({
-  fieldName,
-  control,
-  registerOptions,
-  required,
-  customOnChange,
-  onChange: muiOnChange,
-  onAccept: muiOnAccept,
-  onValueChange,
-  disabled: muiDisabled,
-  label,
-  showLabelAboveFormField,
-  formLabelProps,
-  hideLabel,
-  errorMessage,
-  renderError,
-  hideErrorMessage,
-  helperText,
-  formHelperTextProps,
-  slotProps: muiSlotProps,
-  customIds,
-  ...otherStaticDateTimePickerProps
-}: RHFStaticDateTimePickerProps<T>): JSX.Element => {
+const RHFStaticDateTimePickerInner = forwardRef(function RHFStaticDateTimePicker<
+  T extends FieldValues
+>(
+  {
+    fieldName,
+    control,
+    registerOptions,
+    required,
+    customOnChange,
+    onChange: muiOnChange,
+    onAccept: muiOnAccept,
+    onValueChange,
+    disabled: muiDisabled,
+    label,
+    showLabelAboveFormField,
+    formLabelProps,
+    hideLabel,
+    errorMessage,
+    renderError,
+    hideErrorMessage,
+    helperText,
+    formHelperTextProps,
+    slotProps: muiSlotProps,
+    customIds,
+    ...otherStaticDateTimePickerProps
+  }: RHFStaticDateTimePickerProps<T>,
+  ref: Ref<HTMLDivElement>
+) {
   const {
     dateAdapter,
     allLabelsAboveFields,
@@ -200,6 +208,7 @@ const RHFStaticDateTimePicker = <T extends FieldValues>({
         render={({
           field: {
             value: rhfValue,
+            ref: rhfRef,
             onChange: rhfOnChange,
             onBlur: rhfOnBlur,
             disabled: rhfDisabled
@@ -216,6 +225,7 @@ const RHFStaticDateTimePicker = <T extends FieldValues>({
               {...otherStaticDateTimePickerProps}
               fieldName={fieldName}
               required={isFieldRequired}
+              ref={mergeRefs(rhfRef, ref)}
               value={rhfValue}
               onValueChange={({ newValue, context }) => {
                 muiOnChange?.(newValue, context);
@@ -259,6 +269,12 @@ const RHFStaticDateTimePicker = <T extends FieldValues>({
       />
     </MUIComponentsConfigProvider>
   );
-};
+});
+
+const RHFStaticDateTimePicker = RHFStaticDateTimePickerInner as <
+  T extends FieldValues
+>(
+  props: RHFStaticDateTimePickerProps<T> & { ref?: Ref<HTMLDivElement> }
+) => JSX.Element;
 
 export default RHFStaticDateTimePicker;

--- a/packages/rhf-mui-components/src/mui-pickers/date/RHFStaticDatePicker.tsx
+++ b/packages/rhf-mui-components/src/mui-pickers/date/RHFStaticDatePicker.tsx
@@ -2,8 +2,10 @@
 
 import {
   useContext,
+  forwardRef,
   type ReactNode,
-  type JSX
+  type JSX,
+  type Ref
 } from 'react';
 import {
   Controller,
@@ -30,6 +32,7 @@ import type { CustomComponentIds } from '@/types';
 import {
   generateDateAdapterErrMsg,
   keepLabelAboveFormField,
+  mergeRefs,
   mergeSx,
   resolveRequired
 } from '@/utils';
@@ -143,29 +146,34 @@ export type RHFStaticDatePickerProps<T extends FieldValues> = {
   customIds?: CustomComponentIds;
 } & StaticDatePickerInputProps;
 
-const RHFStaticDatePicker = <T extends FieldValues>({
-  fieldName,
-  control,
-  registerOptions,
-  required,
-  customOnChange,
-  onChange: muiOnChange,
-  onAccept: muiOnAccept,
-  onValueChange,
-  disabled: muiDisabled,
-  label,
-  showLabelAboveFormField,
-  formLabelProps,
-  hideLabel,
-  errorMessage,
-  renderError,
-  hideErrorMessage,
-  helperText,
-  formHelperTextProps,
-  slotProps: muiSlotProps,
-  customIds,
-  ...otherStaticDatePickerProps
-}: RHFStaticDatePickerProps<T>): JSX.Element => {
+const RHFStaticDatePickerInner = forwardRef(function RHFStaticDatePicker<
+  T extends FieldValues
+>(
+  {
+    fieldName,
+    control,
+    registerOptions,
+    required,
+    customOnChange,
+    onChange: muiOnChange,
+    onAccept: muiOnAccept,
+    onValueChange,
+    disabled: muiDisabled,
+    label,
+    showLabelAboveFormField,
+    formLabelProps,
+    hideLabel,
+    errorMessage,
+    renderError,
+    hideErrorMessage,
+    helperText,
+    formHelperTextProps,
+    slotProps: muiSlotProps,
+    customIds,
+    ...otherStaticDatePickerProps
+  }: RHFStaticDatePickerProps<T>,
+  ref: Ref<HTMLDivElement>
+) {
   const {
     dateAdapter,
     allLabelsAboveFields,
@@ -200,6 +208,7 @@ const RHFStaticDatePicker = <T extends FieldValues>({
         render={({
           field: {
             value: rhfValue,
+            ref: rhfRef,
             onChange: rhfOnChange,
             onBlur: rhfOnBlur,
             disabled: rhfDisabled
@@ -216,6 +225,7 @@ const RHFStaticDatePicker = <T extends FieldValues>({
               {...otherStaticDatePickerProps}
               fieldName={fieldName}
               required={isFieldRequired}
+              ref={mergeRefs(rhfRef, ref)}
               value={rhfValue}
               onValueChange={({ newValue, context }) => {
                 muiOnChange?.(newValue, context);
@@ -259,6 +269,12 @@ const RHFStaticDatePicker = <T extends FieldValues>({
       />
     </MUIComponentsConfigProvider>
   );
-};
+});
+
+const RHFStaticDatePicker = RHFStaticDatePickerInner as <
+  T extends FieldValues
+>(
+  props: RHFStaticDatePickerProps<T> & { ref?: Ref<HTMLDivElement> }
+) => JSX.Element;
 
 export default RHFStaticDatePicker;

--- a/packages/rhf-mui-components/src/mui-pickers/time/RHFStaticTimePicker.tsx
+++ b/packages/rhf-mui-components/src/mui-pickers/time/RHFStaticTimePicker.tsx
@@ -2,8 +2,10 @@
 
 import {
   useContext,
+  forwardRef,
   type ReactNode,
-  type JSX
+  type JSX,
+  type Ref
 } from 'react';
 import {
   Controller,
@@ -30,6 +32,7 @@ import type { CustomComponentIds } from '@/types';
 import {
   generateDateAdapterErrMsg,
   keepLabelAboveFormField,
+  mergeRefs,
   mergeSx,
   resolveRequired
 } from '@/utils';
@@ -143,29 +146,34 @@ export type RHFStaticTimePickerProps<T extends FieldValues> = {
   customIds?: CustomComponentIds;
 } & StaticTimePickerInputProps;
 
-const RHFStaticTimePicker = <T extends FieldValues>({
-  fieldName,
-  control,
-  registerOptions,
-  required,
-  customOnChange,
-  onChange: muiOnChange,
-  onAccept: muiOnAccept,
-  onValueChange,
-  disabled: muiDisabled,
-  label,
-  showLabelAboveFormField,
-  formLabelProps,
-  hideLabel,
-  errorMessage,
-  renderError,
-  hideErrorMessage,
-  helperText,
-  formHelperTextProps,
-  slotProps: muiSlotProps,
-  customIds,
-  ...otherStaticTimePickerProps
-}: RHFStaticTimePickerProps<T>): JSX.Element => {
+const RHFStaticTimePickerInner = forwardRef(function RHFStaticTimePicker<
+  T extends FieldValues
+>(
+  {
+    fieldName,
+    control,
+    registerOptions,
+    required,
+    customOnChange,
+    onChange: muiOnChange,
+    onAccept: muiOnAccept,
+    onValueChange,
+    disabled: muiDisabled,
+    label,
+    showLabelAboveFormField,
+    formLabelProps,
+    hideLabel,
+    errorMessage,
+    renderError,
+    hideErrorMessage,
+    helperText,
+    formHelperTextProps,
+    slotProps: muiSlotProps,
+    customIds,
+    ...otherStaticTimePickerProps
+  }: RHFStaticTimePickerProps<T>,
+  ref: Ref<HTMLDivElement>
+) {
   const {
     dateAdapter,
     allLabelsAboveFields,
@@ -200,6 +208,7 @@ const RHFStaticTimePicker = <T extends FieldValues>({
         render={({
           field: {
             value: rhfValue,
+            ref: rhfRef,
             onChange: rhfOnChange,
             onBlur: rhfOnBlur,
             disabled: rhfDisabled
@@ -216,6 +225,7 @@ const RHFStaticTimePicker = <T extends FieldValues>({
               {...otherStaticTimePickerProps}
               fieldName={fieldName}
               required={isFieldRequired}
+              ref={mergeRefs(rhfRef, ref)}
               value={rhfValue}
               onValueChange={({ newValue, context }) => {
                 muiOnChange?.(newValue, context);
@@ -259,6 +269,12 @@ const RHFStaticTimePicker = <T extends FieldValues>({
       />
     </MUIComponentsConfigProvider>
   );
-};
+});
+
+const RHFStaticTimePicker = RHFStaticTimePickerInner as <
+  T extends FieldValues
+>(
+  props: RHFStaticTimePickerProps<T> & { ref?: Ref<HTMLDivElement> }
+) => JSX.Element;
 
 export default RHFStaticTimePicker;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -233,8 +233,8 @@ importers:
   packages/rhf-mui-components:
     dependencies:
       '@nish1896/mui-components':
-        specifier: ^1.0.4
-        version: 1.0.4(30e90968bbe39f096c7737a24290ad44)
+        specifier: ^1.0.5
+        version: 1.0.5(30e90968bbe39f096c7737a24290ad44)
     devDependencies:
       '@ckeditor/ckeditor5-core':
         specifier: 43.3.0
@@ -2828,8 +2828,8 @@ packages:
       '@eslint/js': '>=9'
       eslint: '>=9'
 
-  '@nish1896/mui-components@1.0.4':
-    resolution: {integrity: sha512-y0+i2Q/471wHAf1mnL4rM+eG69mpl3DHWoT1x+aQl9xLYTYIXykzoHajgNbxV92bmaINWQAp1Ul12gq+0R+cyA==}
+  '@nish1896/mui-components@1.0.5':
+    resolution: {integrity: sha512-Ea0aUDl2TLozq7/CzxBUR0I7Rd/HU2xqTOTZ89PdziDSWB+VNDKPCh2KTkFHD37F6nhO7dGj5GnNC1jDJ5DmvQ==}
     peerDependencies:
       '@mui/icons-material': ^6.0.0 || ^7.0.0
       '@mui/material': ^6.0.0 || ^7.0.0
@@ -12418,7 +12418,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@nish1896/mui-components@1.0.4(30e90968bbe39f096c7737a24290ad44)':
+  '@nish1896/mui-components@1.0.5(30e90968bbe39f096c7737a24290ad44)':
     dependencies:
       '@mui/icons-material': 7.3.11(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
       '@mui/material': 7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)


### PR DESCRIPTION
## **User description**
### ✨ Enhancements
- Updated `@nish1896/mui-components` to **v1.0.5**, which includes a fix for `ref` forwarding in static date and time pickers.

### 🐞 Bug Fixes
- Added `ref` forwarding support to `RHFStaticDatePicker`, `RHFStaticDateTimePicker` and `RHFStaticTimePicker`. The ref is merged with RHF's field ref and attached to each picker's wrapping container (static pickers have no `<input>` to target), so RHF's focus-on-validation-error behavior now correctly scrolls to and focuses these fields on submit.


___

## **CodeAnt-AI Description**
Forward refs for static date and time pickers

### What Changed
- Static date, date-time, and time pickers now accept and forward refs to their wrapping containers
- React Hook Form's field ref is preserved alongside the user-provided ref, enabling focus and scrolling to the picker after validation errors
- Updated the picker dependency to include the related ref-forwarding fix
- Updated package versions and release documentation for v4.2.2

### Impact
`✅ Static pickers focus correctly after validation errors`
`✅ Reliable scrolling to invalid date and time fields`
`✅ Ref support across all RHF static picker variants`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
