### PR TITLE
v3.7.0 - Add missing component props for PasswordInput, Select, Autocompletes and PhoneInput

### DIFF
--- a/apps/rhf-mui-demo/package.json
+++ b/apps/rhf-mui-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-demo",
-  "version": "3.6.1",
+  "version": "3.7.0",
   "private": true,
   "author": "Nishant Kohli",
   "scripts": {

--- a/apps/rhf-mui-docs/package.json
+++ b/apps/rhf-mui-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-docs",
-  "version": "3.6.1",
+  "version": "3.7.0",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/changelog/v3.md
+++ b/changelog/v3.md
@@ -8,7 +8,7 @@
   - `RHFPasswordInput`: `iconButtonProps` for the show/hide toggle button.
   - `RHFSelect`: `menuItemProps` (every option `MenuItem`) and `inputLabelProps` (the inline `InputLabel`).
   - `RHFAutocomplete`, `RHFAutocompleteObject`, `RHFMultiAutocomplete`, `RHFMultiAutocompleteObject`: `circularProgressProps` for the loading spinner.
-  - `MUIPhoneInput`: `countrySelectProps` for the flag/dial-code trigger `Select`.
+  - `RHFPhoneInput`: `countrySelectProps` for the flag/dial-code trigger `Select`.
 
 ### 🐞 Bug Fixes
 - `RHFSelect`: Forward `disabled` prop to `InputLabel` when the field is disabled.

--- a/changelog/v3.md
+++ b/changelog/v3.md
@@ -1,8 +1,22 @@
 # Changelog - v3
 
+## [3.7.0](https://github.com/nishkohli96/rhf-mui-components/tree/v3.7.0)
+
+**Released - 7 August, 2026**
+
+- Exposed previously-unreachable internal sub-component props:
+  - `RHFPasswordInput`: `iconButtonProps` for the show/hide toggle button.
+  - `RHFSelect`: `menuItemProps` (every option `MenuItem`) and `inputLabelProps` (the inline `InputLabel`).
+  - `RHFAutocomplete`, `RHFAutocompleteObject`, `RHFMultiAutocomplete`, `RHFMultiAutocompleteObject`: `circularProgressProps` for the loading spinner.
+  - `MUIPhoneInput`: `countrySelectProps` for the flag/dial-code trigger `Select`.
+
+### 🐞 Bug Fixes
+- `RHFSelect`: Forward `disabled` prop to `InputLabel` when the field is disabled.
+
+
 ## [3.6.1](https://github.com/nishkohli96/rhf-mui-components/tree/v3.6.1)
 
-**Released - 3 August, 2026**
+**Released - 4 August, 2026**
 
 ### ✨ Enhancements
 - Exported `fieldNameToId` function from `form-helpers`module.

--- a/changelog/v3.md
+++ b/changelog/v3.md
@@ -4,6 +4,7 @@
 
 **Released - 7 August, 2026**
 
+### ✨ Enhancements
 - Exposed previously-unreachable internal sub-component props:
   - `RHFPasswordInput`: `iconButtonProps` for the show/hide toggle button.
   - `RHFSelect`: `menuItemProps` (every option `MenuItem`) and `inputLabelProps` (the inline `InputLabel`).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-components-root",
-  "version": "3.6.1",
+  "version": "3.7.0",
   "description": "A suite of 20+ production-ready react-hook-form components built with material-ui. Fully typed, tree-shakable, and optimized for enterprise-grade forms.",
   "author": "Nishant Kohli",
   "private": true,

--- a/packages/rhf-mui-components/package.json
+++ b/packages/rhf-mui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-components",
-  "version": "3.6.1",
+  "version": "3.7.0",
   "description": "A suite of 20+ production-ready react-hook-form components built with material-ui. Fully typed, tree-shakable, and optimized for enterprise-grade forms.",
   "author": "Nishant Kohli",
   "homepage": "https://rhf-mui-components.vercel.app/",

--- a/packages/rhf-mui-components/src/common/types/mui.ts
+++ b/packages/rhf-mui-components/src/common/types/mui.ts
@@ -5,7 +5,11 @@ import type { FormHelperTextProps as MuiFormHelperTextProps } from '@mui/materia
 import type { FormLabelProps as MuiFormLabelProps } from '@mui/material/FormLabel';
 import type { RadioProps as MuiRadioProps } from '@mui/material/Radio';
 import type { SelectProps as MuiSelectProps } from '@mui/material/Select';
+import type { InputLabelProps as MuiInputLabelProps } from '@mui/material/InputLabel';
+import type { MenuItemProps as MuiMenuItemProps } from '@mui/material/MenuItem';
 import type { TextFieldProps as MuiTextFieldProps } from '@mui/material/TextField';
+import type { IconButtonProps as MuiIconButtonProps } from '@mui/material/IconButton';
+import type { CircularProgressProps as MuiCircularProgressProps } from '@mui/material/CircularProgress';
 
 export type FormLabelProps = Omit<
   MuiFormLabelProps,
@@ -70,6 +74,33 @@ export type SelectProps = Omit<
   | 'multiple'
 >;
 
+/**
+ * Props forwarded to an internal MUI `InputLabel` (e.g. `MUISelect`'s inline
+ * label). `id`, `htmlFor`, `shrink`, `disabled` and `children` are omitted
+ * because the component manages them to keep the label wired to the field.
+ */
+export type InputLabelProps = Omit<
+  MuiInputLabelProps,
+  | 'id'
+  | 'htmlFor'
+  | 'shrink'
+  | 'disabled'
+  | 'children'
+>;
+
+/**
+ * Props forwarded to each internal MUI `MenuItem` (e.g. `MUISelect`'s options).
+ * `key`, `value`, `disabled` and `children` are omitted because the component
+ * derives them per-option from `options`/`getOptionDisabled`/`renderOptionLabel`.
+ */
+export type MenuItemProps = Omit<
+  MuiMenuItemProps,
+  | 'key'
+  | 'value'
+  | 'disabled'
+  | 'children'
+>;
+
 export type AutoCompleteTextFieldProps = Omit<
   MuiTextFieldProps,
   | 'value'
@@ -102,4 +133,29 @@ export type MuiChipProps = Omit<
   | 'label'
   | 'onDelete'
   | 'disabled'
+>;
+
+/**
+ * Props forwarded to an internal MUI `CircularProgress` (the Autocomplete
+ * family's loading spinner). Nothing is omitted — `color`/`size` have sane
+ * defaults but are safe to override.
+ */
+export type CircularProgressProps = MuiCircularProgressProps;
+
+/**
+ * Props forwarded to an internal MUI `IconButton` (e.g. `MUIPasswordInput`'s
+ * show/hide toggle). The interaction/accessibility essentials are omitted
+ * because the component owns them — `type`, `onClick`, `onMouseDown`, `edge`,
+ * `disabled`, `aria-label` and `children` are always set correctly regardless
+ * of what's passed here.
+ */
+export type IconButtonProps = Omit<
+  MuiIconButtonProps,
+  | 'type'
+  | 'onClick'
+  | 'onMouseDown'
+  | 'edge'
+  | 'disabled'
+  | 'aria-label'
+  | 'children'
 >;

--- a/packages/rhf-mui-components/src/misc/phone-input/index.tsx
+++ b/packages/rhf-mui-components/src/misc/phone-input/index.tsx
@@ -24,7 +24,7 @@ import {
 import MuiTextField, { type TextFieldProps } from '@mui/material/TextField';
 import InputAdornment from '@mui/material/InputAdornment';
 import Divider from '@mui/material/Divider';
-import Select from '@mui/material/Select';
+import Select, { type SelectProps as MuiSelectProps } from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
 import Typography from '@mui/material/Typography';
 import {
@@ -52,7 +52,8 @@ import {
   keepLabelAboveFormField,
   isAboveMuiV5,
   useFieldIds,
-  resolveRequired
+  resolveRequired,
+  mergeSx
 } from '@/utils';
 import 'react-international-phone/style.css';
 
@@ -81,6 +82,26 @@ type InputTextFieldProps = Omit<
   | 'inputRef'
   | 'type'
   | 'FormHelperTextProps'
+>;
+
+/**
+ * Props forwarded to the internal MUI `Select` that renders the flag/dial-code
+ * trigger and country dropdown.
+ */
+type CountrySelectProps = Omit<
+  MuiSelectProps,
+  | 'value'
+  | 'defaultValue'
+  | 'multiple'
+  | 'onChange'
+  | 'onOpen'
+  | 'onClose'
+  | 'multiline'
+  | 'renderValue'
+  | 'MenuProps'
+  | 'disabled'
+  | 'children'
+  | 'ref'
 >;
 
 type PhoneInputProps = Omit<UsePhoneInputConfig, 'value' | 'onChange'> & {
@@ -133,6 +154,12 @@ export type RHFPhoneInputProps<T extends FieldValues> = {
    */
   formHelperTextProps?: Omit<FormHelperTextProps, 'id'>;
   /**
+   * Props forwarded to the internal MUI `Select` that renders the flag/dial-code
+   * trigger and country dropdown — e.g. a custom `size` or `sx` (merged with
+   * the component's own). See `CountrySelectProps` for what's excluded and why.
+   */
+  countrySelectProps?: CountrySelectProps;
+  /**
    * Configuration passed to `react-international-phone`'s `usePhoneInput` hook.
    */
   phoneInputProps?: PhoneInputProps;
@@ -153,9 +180,10 @@ const RHFPhoneInput = <T extends FieldValues>({
   hideErrorMessage,
   formHelperTextProps,
   disabled: muiDisabled,
+  countrySelectProps,
   phoneInputProps,
   slotProps,
-  onBlur,
+  onBlur: muiOnBlur,
   autoComplete = defaultAutocompleteValue,
   InputProps,
   ...otherTextFieldProps
@@ -284,6 +312,7 @@ const RHFPhoneInput = <T extends FieldValues>({
             style={{ marginRight: '2px', marginLeft: '-8px' }}
           >
             <Select
+              {...countrySelectProps}
               MenuProps={{
                 autoFocus: false,
                 ...(countryMenuAnchorEl ? { anchorEl: countryMenuAnchorEl } : {}),
@@ -304,24 +333,27 @@ const RHFPhoneInput = <T extends FieldValues>({
                   }
                 }
               }}
-              sx={{
-                width: 'max-content',
-                fieldset: {
-                  display: 'none'
-                },
-                '&.Mui-focused:has(div[aria-expanded="false"])': {
+              sx={mergeSx(
+                {
+                  width: 'max-content',
                   fieldset: {
-                    display: 'block'
+                    display: 'none'
+                  },
+                  '&.Mui-focused:has(div[aria-expanded="false"])': {
+                    fieldset: {
+                      display: 'block'
+                    }
+                  },
+                  '.MuiSelect-select': {
+                    padding: '8px',
+                    paddingRight: '24px !important'
+                  },
+                  svg: {
+                    right: 0
                   }
                 },
-                '.MuiSelect-select': {
-                  padding: '8px',
-                  paddingRight: '24px !important'
-                },
-                svg: {
-                  right: 0
-                }
-              }}
+                countrySelectProps?.sx
+              )}
               value={country.iso2}
               disabled={isDisabled || hideDropdown}
               onOpen={updateCountryMenuLayout}
@@ -405,7 +437,7 @@ const RHFPhoneInput = <T extends FieldValues>({
               }}
               onBlur={blurEvent => {
                 rhfOnBlur();
-                onBlur?.(blurEvent);
+                muiOnBlur?.(blurEvent);
               }}
               label={
                 !isLabelAboveFormField

--- a/packages/rhf-mui-components/src/mui/autocomplete-object/index.tsx
+++ b/packages/rhf-mui-components/src/mui/autocomplete-object/index.tsx
@@ -31,7 +31,8 @@ import {
   type FormLabelProps,
   type FormHelperTextProps,
   type AutoCompleteTextFieldProps,
-  type MuiChipProps
+  type MuiChipProps,
+  type CircularProgressProps
 } from '@/common';
 import { RHFMuiConfigContext } from '@/config/ConfigProvider';
 import type { KeyValueOption } from '@/types';
@@ -173,6 +174,11 @@ export type RHFAutocompleteObjectProps<
    * Props forwarded to chips rendered for selected values.
    */
   ChipProps?: MuiChipProps;
+  /**
+   * Props forwarded to the internal MUI `CircularProgress` shown in the input
+   * while `loading` is true.
+   */
+  circularProgressProps?: CircularProgressProps;
 } & OmittedAutocompleteProps<Option, Multiple, DisableClearable>;
 
 const RHFAutocompleteObject = <
@@ -204,7 +210,8 @@ const RHFAutocompleteObject = <
   textFieldProps,
   slotProps,
   ChipProps,
-  onBlur,
+  circularProgressProps,
+  onBlur: muiOnBlur,
   loading,
   ...otherAutoCompleteProps
 }: RHFAutocompleteObjectProps<
@@ -318,7 +325,7 @@ const RHFAutocompleteObject = <
               }}
               onBlur={blurEvent => {
                 rhfOnBlur();
-                onBlur?.(blurEvent);
+                muiOnBlur?.(blurEvent);
               }}
               limitTags={2}
               getLimitTagsText={value => `+${value} More`}
@@ -392,7 +399,11 @@ const RHFAutocompleteObject = <
                           endAdornment: (
                             <>
                               {loading && (
-                                <CircularProgress color="inherit" size={20} />
+                                <CircularProgress
+                                  color="inherit"
+                                  size={20}
+                                  {...circularProgressProps}
+                                />
                               )}
                               {InputProps?.endAdornment}
                             </>

--- a/packages/rhf-mui-components/src/mui/autocomplete-object/index.tsx
+++ b/packages/rhf-mui-components/src/mui/autocomplete-object/index.tsx
@@ -383,6 +383,7 @@ const RHFAutocompleteObject = <
                                   <CircularProgress
                                     color="inherit"
                                     size={20}
+                                    {...circularProgressProps}
                                   />
                                 )}
                                 {InputProps?.endAdornment}

--- a/packages/rhf-mui-components/src/mui/autocomplete/index.tsx
+++ b/packages/rhf-mui-components/src/mui/autocomplete/index.tsx
@@ -435,7 +435,11 @@ const RHFAutocomplete = <
                           endAdornment: (
                             <>
                               {loading && (
-                                <CircularProgress color="inherit" size={20} />
+                                <CircularProgress
+                                  color="inherit"
+                                  size={20}
+                                  {...circularProgressProps}
+                                />
                               )}
                               {InputProps?.endAdornment}
                             </>

--- a/packages/rhf-mui-components/src/mui/autocomplete/index.tsx
+++ b/packages/rhf-mui-components/src/mui/autocomplete/index.tsx
@@ -32,7 +32,8 @@ import {
   type FormLabelProps,
   type FormHelperTextProps,
   type AutoCompleteTextFieldProps,
-  type MuiChipProps
+  type MuiChipProps,
+  type CircularProgressProps
 } from '@/common';
 import { RHFMuiConfigContext } from '@/config/ConfigProvider';
 import type {
@@ -178,6 +179,11 @@ export type RHFAutocompleteProps<
    * Props forwarded to chips rendered for selected values.
    */
   ChipProps?: MuiChipProps;
+  /**
+   * Props forwarded to the internal MUI `CircularProgress` shown in the input
+   * while `loading` is true.
+   */
+  circularProgressProps?: CircularProgressProps;
 } & OmittedAutocompleteProps<Option, Multiple, DisableClearable>;
 
 const RHFAutocomplete = <
@@ -209,7 +215,8 @@ const RHFAutocomplete = <
   textFieldProps,
   slotProps,
   ChipProps,
-  onBlur,
+  circularProgressProps,
+  onBlur: muiOnBlur,
   loading,
   ...otherAutoCompleteProps
 }: RHFAutocompleteProps<T, Option, LabelKey, ValueKey, Multiple, DisableClearable>) => {
@@ -350,7 +357,7 @@ const RHFAutocomplete = <
               }}
               onBlur={blurEvent => {
                 rhfOnBlur();
-                onBlur?.(blurEvent);
+                muiOnBlur?.(blurEvent);
               }}
               limitTags={2}
               getLimitTagsText={value => `+${value} More`}
@@ -411,6 +418,7 @@ const RHFAutocomplete = <
                                   <CircularProgress
                                     color="inherit"
                                     size={20}
+                                    {...circularProgressProps}
                                   />
                                 )}
                                 {InputProps?.endAdornment}

--- a/packages/rhf-mui-components/src/mui/multi-autocomplete-object/index.tsx
+++ b/packages/rhf-mui-components/src/mui/multi-autocomplete-object/index.tsx
@@ -466,7 +466,11 @@ const RHFMultiAutocompleteObject = <
                           endAdornment: (
                             <>
                               {loading && (
-                                <CircularProgress color="inherit" size={20} />
+                                <CircularProgress
+                                  color="inherit"
+                                  size={20}
+                                  {...circularProgressProps}
+                                />
                               )}
                               {InputProps.endAdornment}
                             </>

--- a/packages/rhf-mui-components/src/mui/multi-autocomplete-object/index.tsx
+++ b/packages/rhf-mui-components/src/mui/multi-autocomplete-object/index.tsx
@@ -35,7 +35,8 @@ import {
   type CheckboxProps,
   type FormHelperTextProps,
   type AutoCompleteTextFieldProps,
-  type MuiChipProps
+  type MuiChipProps,
+  type CircularProgressProps
 } from '@/common';
 import { RHFMuiConfigContext } from '@/config/ConfigProvider';
 import type { KeyValueOption } from '@/types';
@@ -176,6 +177,11 @@ export type RHFMultiAutocompleteObjectProps<
    * Props forwarded to chips rendered for selected values.
    */
   ChipProps?: MuiChipProps;
+  /**
+   * Props forwarded to the internal MUI `CircularProgress` shown in the input
+   * while `loading` is true.
+   */
+  circularProgressProps?: CircularProgressProps;
 } & MultiAutoCompleteProps<Option, DisableClearable>;
 
 const RHFMultiAutocompleteObject = <
@@ -209,7 +215,8 @@ const RHFMultiAutocompleteObject = <
   textFieldProps,
   slotProps,
   ChipProps,
-  onBlur,
+  circularProgressProps,
+  onBlur: muiOnBlur,
   loading,
   ...otherAutoCompleteProps
 }: RHFMultiAutocompleteObjectProps<
@@ -368,7 +375,7 @@ const RHFMultiAutocompleteObject = <
               }}
               onBlur={blurEvent => {
                 rhfOnBlur();
-                onBlur?.(blurEvent);
+                muiOnBlur?.(blurEvent);
               }}
               limitTags={2}
               getLimitTagsText={value => `+${value} More`}
@@ -439,8 +446,10 @@ const RHFMultiAutocompleteObject = <
                             endAdornment: (
                               <>
                                 {loading && (
-                                  <CircularProgress color="inherit"
+                                  <CircularProgress
+                                    color="inherit"
                                     size={20}
+                                    {...circularProgressProps}
                                   />
                                 )}
                                 {InputProps.endAdornment}

--- a/packages/rhf-mui-components/src/mui/multi-autocomplete/index.tsx
+++ b/packages/rhf-mui-components/src/mui/multi-autocomplete/index.tsx
@@ -35,7 +35,8 @@ import {
   type CheckboxProps,
   type FormHelperTextProps,
   type AutoCompleteTextFieldProps,
-  type MuiChipProps
+  type MuiChipProps,
+  type CircularProgressProps
 } from '@/common';
 import { RHFMuiConfigContext } from '@/config/ConfigProvider';
 import type { KeyValueOption, StrObjOption, } from '@/types';
@@ -179,6 +180,11 @@ export type RHFMultiAutocompleteProps<
    * Props forwarded to chips rendered for selected values.
    */
   ChipProps?: MuiChipProps;
+  /**
+   * Props forwarded to the internal MUI `CircularProgress` shown in the input
+   * while `loading` is true.
+   */
+  circularProgressProps?: CircularProgressProps;
 } & MultiAutoCompleteProps<Option, DisableClearable>;
 
 const RHFMultiAutocomplete = <
@@ -212,7 +218,8 @@ const RHFMultiAutocomplete = <
   textFieldProps,
   slotProps,
   ChipProps,
-  onBlur,
+  circularProgressProps,
+  onBlur: muiOnBlur,
   loading,
   ...otherAutoCompleteProps
 }: RHFMultiAutocompleteProps<
@@ -388,7 +395,7 @@ const RHFMultiAutocomplete = <
               }}
               onBlur={blurEvent => {
                 rhfOnBlur();
-                onBlur?.(blurEvent);
+                muiOnBlur?.(blurEvent);
               }}
               limitTags={2}
               getLimitTagsText={value => `+${value} More`}
@@ -477,7 +484,11 @@ const RHFMultiAutocomplete = <
                           endAdornment: (
                             <>
                               {loading && (
-                                <CircularProgress color="inherit" size={20} />
+                                <CircularProgress
+                                  color="inherit"
+                                  size={20}
+                                  {...circularProgressProps}
+                                />
                               )}
                               {InputProps.endAdornment}
                             </>

--- a/packages/rhf-mui-components/src/mui/multi-autocomplete/index.tsx
+++ b/packages/rhf-mui-components/src/mui/multi-autocomplete/index.tsx
@@ -466,8 +466,10 @@ const RHFMultiAutocomplete = <
                             endAdornment: (
                               <>
                                 {loading && (
-                                  <CircularProgress color="inherit"
+                                  <CircularProgress
+                                    color="inherit"
                                     size={20}
+                                    {...circularProgressProps}
                                   />
                                 )}
                                 {InputProps.endAdornment}

--- a/packages/rhf-mui-components/src/mui/password-input/index.tsx
+++ b/packages/rhf-mui-components/src/mui/password-input/index.tsx
@@ -27,7 +27,8 @@ import {
   defaultAutocompleteValue,
   type FormLabelProps,
   type FormHelperTextProps,
-  type TextFieldProps
+  type TextFieldProps,
+  type IconButtonProps
 } from '@/common';
 import { RHFMuiConfigContext } from '@/config/ConfigProvider';
 import {
@@ -94,6 +95,12 @@ export type RHFPasswordInputProps<T extends FieldValues> = {
    */
   hidePasswordIcon?: ReactNode;
   /**
+   * Props forwarded to the internal MUI `IconButton` that toggles password
+   * visibility. Use `showPasswordIcon`/`hidePasswordIcon` to swap the icon
+   * itself; this is for the button around it — e.g. a custom `size` or `sx`.
+   */
+  iconButtonProps?: IconButtonProps;
+  /**
    * When true, the value is displayed but cannot be edited.
    *
    * Unlike `disabled`, the field stays focusable, is still submitted with the
@@ -129,6 +136,7 @@ const RHFPasswordInput = <T extends FieldValues>({
   formLabelProps,
   showPasswordIcon,
   hidePasswordIcon,
+  iconButtonProps,
   readOnly,
   required,
   helperText,
@@ -198,6 +206,7 @@ const RHFPasswordInput = <T extends FieldValues>({
         const endAdornment = (
           <InputAdornment position="end">
             <IconButton
+              {...iconButtonProps}
               type="button"
               aria-label={showPassword ? 'Hide password' : 'Show password'}
               onClick={handleClickShowPassword}

--- a/packages/rhf-mui-components/src/mui/select/index.tsx
+++ b/packages/rhf-mui-components/src/mui/select/index.tsx
@@ -20,6 +20,8 @@ import {
   type FormLabelProps,
   type FormHelperTextProps,
   type SelectProps,
+  type InputLabelProps,
+  type MenuItemProps,
   type OptionValue
 } from '@/common';
 import { RHFMuiConfigContext } from '@/config/ConfigProvider';
@@ -84,6 +86,12 @@ export type RHFSelectProps<
    */
   multiple?: Multiple;
   /**
+   * Props forwarded to each internal MUI `MenuItem`, applied to every rendered
+   * option — including the default placeholder option when `showDefaultOption`
+   * is enabled. Useful for a custom `dense`, `divider` or `sx` across all options.
+   */
+  menuItemProps?: MenuItemProps;
+  /**
    * When `true`, displays a default placeholder option at the top of the
    * dropdown menu.
    *
@@ -119,6 +127,13 @@ export type RHFSelectProps<
    * Props forwarded to the internal `FormLabel`. The `id` is managed by the component.
    */
   formLabelProps?: Omit<FormLabelProps, 'id'>;
+  /**
+   * Props forwarded to the internal MUI `InputLabel` — the inline label shown
+   * inside the field's outline when `showLabelAboveFormField` is off. Has no
+   * effect when that label isn't rendered (`showLabelAboveFormField`,
+   * or a `placeholder` with no value selected).
+   */
+  inputLabelProps?: InputLabelProps;
   /**
    * Helper text shown below the field when there is no visible validation error.
    */
@@ -160,6 +175,7 @@ const RHFSelect = <
   labelKey,
   valueKey,
   multiple,
+  menuItemProps,
   showDefaultOption,
   defaultOptionText,
   onValueChange,
@@ -167,6 +183,7 @@ const RHFSelect = <
   label,
   showLabelAboveFormField,
   formLabelProps,
+  inputLabelProps,
   required,
   helperText,
   errorMessage,
@@ -242,7 +259,12 @@ const RHFSelect = <
             />
             <Fragment>
               {!isLabelAboveFormField && !showPlaceholder && (
-                <InputLabel id={labelId} shrink={!isValueEmpty}>
+                <InputLabel
+                  {...inputLabelProps}
+                  id={labelId}
+                  shrink={!isValueEmpty}
+                  disabled={isDisabled}
+                >
                   {SelectFormLabel}
                 </InputLabel>
               )}
@@ -325,7 +347,11 @@ const RHFSelect = <
                 }}
               >
                 {showDefaultOption && (
-                  <MenuItem value="" disabled={isFieldRequired}>
+                  <MenuItem
+                    {...menuItemProps}
+                    value=""
+                    disabled={isFieldRequired}
+                  >
                     {defaultOptionText ?? `Select ${fieldLabelText}`}
                   </MenuItem>
                 )}
@@ -339,7 +365,11 @@ const RHFSelect = <
                     ? String(option[labelKey!])
                     : String(option);
                   return (
-                    <MenuItem key={opnValue} value={opnValue}>
+                    <MenuItem
+                      {...menuItemProps}
+                      key={opnValue}
+                      value={opnValue}
+                    >
                       {opnLabel}
                     </MenuItem>
                   );

--- a/packages/rhf-mui-components/src/utils/mui.ts
+++ b/packages/rhf-mui-components/src/utils/mui.ts
@@ -1,4 +1,5 @@
 import muiPackage from '@mui/material/package.json';
+import type { SxProps, Theme } from '@mui/material/styles';
 
 /**
  * After migrating from MUI v5 to v6, some of the props like "InputProps"
@@ -7,3 +8,23 @@ import muiPackage from '@mui/material/package.json';
  * being passed to any of the components in v6 or above.
  */
 export const isAboveMuiV5 = !(muiPackage.version.startsWith('5.'));
+
+type SxInput = SxProps<Theme> | undefined;
+
+/**
+ * Combine several `sx` values into a single `sx` array.
+ *
+ * MUI's `sx` accepts an object, a theme-callback function, or an array of those.
+ * Object-spreading two `sx` values (`{ ...a, ...b }`) silently breaks the last
+ * two forms — an array collapses into numeric keys and a callback loses its
+ * behaviour. Flattening into an array preserves every form. Later sources still
+ * win, matching object-spread precedence.
+ */
+export function mergeSx(...sources: SxInput[]): SxProps<Theme> {
+  return sources.flatMap(sx => {
+    if (Array.isArray(sx)) {
+      return sx;
+    }
+    return sx ? [sx] : [];
+  });
+}


### PR DESCRIPTION
## **User description**
### ✨ Enhancements
- Exposed previously-unreachable internal sub-component props:
  - `RHFPasswordInput`: `iconButtonProps` for the show/hide toggle button.
  - `RHFSelect`: `menuItemProps` (every option `MenuItem`) and `inputLabelProps` (the inline `InputLabel`).
  - `RHFAutocomplete`, `RHFAutocompleteObject`, `RHFMultiAutocomplete`, `RHFMultiAutocompleteObject`: `circularProgressProps` for the loading spinner.
  - `RHFPhoneInput`: `countrySelectProps` for the flag/dial-code trigger `Select`.

### 🐞 Bug Fixes
- `RHFSelect`: Forward `disabled` prop to `InputLabel` when the field is disabled.


___

## **CodeAnt-AI Description**
Expose customization options for internal form controls in v3.7.0

### What Changed
- Password fields can customize the show/hide button, phone fields can customize the country selector, and select fields can customize labels and options.
- Autocomplete loading indicators can now be styled and configured.
- Disabled select fields now visibly disable their inline labels.
- Phone selector styling preserves the component’s built-in layout while applying user-provided styles.
- Package and demo applications are updated to version 3.7.0.

### Impact
`✅ More control over form field appearance`
`✅ Customizable autocomplete loading indicators`
`✅ Clearer disabled select fields`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
