### PR TITLE
v4.3.0 - Update mui-components to v1.1; added new props; bug fixes; updated v3 and v4 docs

### DIFF
--- a/apps/rhf-mui-demo/package.json
+++ b/apps/rhf-mui-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-demo",
-  "version": "4.2.2",
+  "version": "4.3.0",
   "private": true,
   "author": "Nishant Kohli",
   "scripts": {

--- a/apps/rhf-mui-demo/src/forms/inputs-with-register-options/index.tsx
+++ b/apps/rhf-mui-demo/src/forms/inputs-with-register-options/index.tsx
@@ -187,6 +187,9 @@ const InputsWithRegisterForm = () => {
                 }
               }}
               placeholder="Enter a secure password"
+              iconButtonProps={{
+                color: 'success'
+              }}
               hideLabel
               required
             />

--- a/apps/rhf-mui-docs/docs/components/mui/RHFAutocompleteObject.mdx
+++ b/apps/rhf-mui-docs/docs/components/mui/RHFAutocompleteObject.mdx
@@ -7,9 +7,8 @@ description: Autocomplete component that returns full option objects instead of 
 
 import { RHFAutocompleteObjectPropsTable } from '@site/src/page-components';
 import { AvailabilityBanner, DemoLink } from '@site/src/components';
-import NewImg from '@site/static/img/new.png';
 
-# RHFAutocompleteObject<sup><img src={NewImg} alt="NEW" height="40" /></sup>
+# RHFAutocompleteObject
 
 <AvailabilityBanner componentName="RHFAutocompleteObject" version="3.3" />
 

--- a/apps/rhf-mui-docs/docs/components/mui/RHFMultiAutocompleteObject.mdx
+++ b/apps/rhf-mui-docs/docs/components/mui/RHFMultiAutocompleteObject.mdx
@@ -7,9 +7,8 @@ description: Multi-select autocomplete component with object-based values and bu
 
 import { RHFMultiAutocompleteObjectPropsTable } from '@site/src/page-components';
 import { AvailabilityBanner, DemoLink } from '@site/src/components';
-import NewImg from '@site/static/img/new.png';
 
-# RHFMultiAutocompleteObject<sup><img src={NewImg} alt="NEW" height="40" /></sup>
+# RHFMultiAutocompleteObject
 
 <AvailabilityBanner componentName="RHFMultiAutocompleteObject" version="3.3" />
 

--- a/apps/rhf-mui-docs/package.json
+++ b/apps/rhf-mui-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-docs",
-  "version": "4.2.2",
+  "version": "4.3.0",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/apps/rhf-mui-docs/src/constants/external-links.ts
+++ b/apps/rhf-mui-docs/src/constants/external-links.ts
@@ -25,6 +25,10 @@ const ExternalLinks = Object.freeze({
       `https://${muiVersion ? `v${muiVersion}.` : ''}mui.com/material-ui/react-switch/`,
     chip: (muiVersion?: MuiVersion) =>
       `https://${muiVersion ? `v${muiVersion}.` : ''}mui.com/material-ui/react-chip/`,
+    iconButton: (muiVersion?: MuiVersion) =>
+      `https://${muiVersion ? `v${muiVersion}.` : ''}mui.com/material-ui/react-button/#icon-button`,
+    circularProgress: (muiVersion?: MuiVersion) =>
+      `https://${muiVersion ? `v${muiVersion}.` : ''}mui.com/material-ui/react-progress/#circular`
   },
   muiComponentApi: {
     textField: (muiVersion?: MuiVersion) =>
@@ -50,6 +54,14 @@ const ExternalLinks = Object.freeze({
       `https://${muiVersion ? `v${muiVersion}.` : ''}mui.com/material-ui/api/chip/`,
     box: (muiVersion?: MuiVersion) =>
       `https://${muiVersion ? `v${muiVersion}.` : ''}mui.com/material-ui/api/box/`,
+    menuItem: (muiVersion?: MuiVersion) =>
+      `https://${muiVersion ? `v${muiVersion}.` : ''}mui.com/material-ui/api/menu-item/`,
+    inputLabel: (muiVersion?: MuiVersion) =>
+      `https://${muiVersion ? `v${muiVersion}.` : ''}mui.com/material-ui/api/input-label/`,
+    iconButton: (muiVersion?: MuiVersion) =>
+      `https://${muiVersion ? `v${muiVersion}.` : ''}mui.com/material-ui/api/icon-button/`,
+    circularProgress: (muiVersion?: MuiVersion) =>
+      `https://${muiVersion ? `v${muiVersion}.` : ''}mui.com/material-ui/api/circular-progress/`,
   },
   rhfApi: {
     control: 'https://react-hook-form.com/docs/useform/control',

--- a/apps/rhf-mui-docs/src/constants/legacy-props.ts
+++ b/apps/rhf-mui-docs/src/constants/legacy-props.ts
@@ -316,7 +316,37 @@ const LegacyPropsDescription: Record<
     name: 'onBlur',
     description: 'Callback function that returns the blur event when the file uploader component loses focus. Added in `v3.6.0`.',
     type: '(event: FocusEvent) => void'
-  }
+  },
+  menuItemProps_Select_v3: ({ muiVersion }: PropsDescriptionArgs) => ({
+    name: 'menuItemProps',
+    description: 'Props forwarded to each internal MUI `MenuItem`, applied to every rendered option. Added in `v3.7`.',
+    type: `[MenuItemProps](${ExternalLinks.muiComponentApi.menuItem(muiVersion)})`,
+    hasLinkInType: true
+  }),
+  inputLabelProps_Select_v3: ({ muiVersion }: PropsDescriptionArgs) => ({
+    name: 'inputLabelProps',
+    description: 'Props forwarded to the `InputLabel` — the inline label shown inside the field\'s outline. Added in `v4.3`.',
+    type: `[InputLabelProps](${ExternalLinks.muiComponentApi.inputLabel(muiVersion)})`,
+    hasLinkInType: true
+  }),
+  iconButtonProps_PasswordInput_v3: ({ muiVersion }: PropsDescriptionArgs) => ({
+    name: 'iconButtonProps',
+    description: `Props forwarded to the [IconButton](${ExternalLinks.muiComponents.iconButton(muiVersion)}) component that toggles password visibility. Added in \`v3.7.0\`.`,
+    type: `[IconButtonProps](${ExternalLinks.muiComponentApi.iconButton(muiVersion)})`,
+    hasLinkInType: true
+  }),
+  circularProgressProps_Autocompletes_v3: ({ muiVersion }: PropsDescriptionArgs) => ({
+    name: 'circularProgressProps',
+    description: `Props forwarded to the [CircularProgress](${ExternalLinks.muiComponents.circularProgress(muiVersion)}) displayed in the autocomplete input when it is \`loading\`. Added in \`v3.7\`.`,
+    type: `[CircularProgressProps](${ExternalLinks.muiComponentApi.circularProgress(muiVersion)})`,
+    hasLinkInType: true
+  }),
+  countrySelectProps_v3: ({ muiVersion }: PropsDescriptionArgs) => ({
+    name: 'countrySelectProps',
+    description: `Props forwarded to the internal [Select](${ExternalLinks.muiComponents.select(muiVersion)}}) that renders the flag/dial-code trigger and country dropdown. Added in \`v3.7\`.`,
+    type: `[SelectProps](${ExternalLinks.muiComponentApi.select(muiVersion)})`,
+    hasLinkInType: true
+  }),
 });
 
 export default LegacyPropsDescription;

--- a/apps/rhf-mui-docs/src/constants/legacy-props.ts
+++ b/apps/rhf-mui-docs/src/constants/legacy-props.ts
@@ -325,7 +325,7 @@ const LegacyPropsDescription: Record<
   }),
   inputLabelProps_Select_v3: ({ muiVersion }: PropsDescriptionArgs) => ({
     name: 'inputLabelProps',
-    description: 'Props forwarded to the `InputLabel` — the inline label shown inside the field\'s outline. Added in `v4.3`.',
+    description: 'Props forwarded to the `InputLabel` — the inline label shown inside the field\'s outline. Added in `v3.7`.',
     type: `[InputLabelProps](${ExternalLinks.muiComponentApi.inputLabel(muiVersion)})`,
     hasLinkInType: true
   }),

--- a/apps/rhf-mui-docs/src/constants/props.ts
+++ b/apps/rhf-mui-docs/src/constants/props.ts
@@ -487,6 +487,12 @@ const PropsDescription: Record<
       'Custom icon displayed when the password value is visible, such as `VisibilityOffIcon` from `@mui/icons-material/VisibilityOff`.',
     type: 'ReactNode'
   },
+  iconButtonProps_PasswordInput: ({ muiVersion }: PropsDescriptionArgs) => ({
+    name: 'iconButtonProps',
+    description: `Props forwarded to the [IconButton](${ExternalLinks.muiComponents.iconButton(muiVersion)}) component that toggles password visibility. Added in \`v4.3.0\`.`,
+    type: `[IconButtonProps](${ExternalLinks.muiComponentApi.iconButton(muiVersion)})`,
+    hasLinkInType: true
+  }),
   readOnly_PasswordInput: {
     name: 'readOnly',
     description:
@@ -584,6 +590,18 @@ const PropsDescription: Record<
       'Custom text to replace the default text when `showDefaultOption` is `true` for `RHFSelect` or `RHFNativeSelect`.',
     type: 'string'
   },
+  menuItemProps_Select: ({ muiVersion }: PropsDescriptionArgs) => ({
+    name: 'menuItemProps',
+    description: 'Props forwarded to each internal MUI `MenuItem`, applied to every rendered option. Added in `v4.3`.',
+    type: `[MenuItemProps](${ExternalLinks.muiComponentApi.menuItem(muiVersion)})`,
+    hasLinkInType: true
+  }),
+  inputLabelProps_Select: ({ muiVersion }: PropsDescriptionArgs) => ({
+    name: 'inputLabelProps',
+    description: 'Props forwarded to the `InputLabel` — the inline label shown inside the field\'s outline. Added in `v4.3`.',
+    type: `[InputLabelProps](${ExternalLinks.muiComponentApi.inputLabel(muiVersion)})`,
+    hasLinkInType: true
+  }),
   checkboxProps: ({ muiVersion }: PropsDescriptionArgs) => ({
     name: 'checkboxProps',
     description: `[Checkbox Props](${ExternalLinks.muiComponentApi.checkbox(muiVersion)}) to customise each checkbox in checkbox group.`,
@@ -688,6 +706,12 @@ const PropsDescription: Record<
       'Custom text to render in place of the "**Select All**" option that enables user to select all available options in the Autocomplete.',
     type: 'string'
   },
+  circularProgressProps_Autocompletes: ({ muiVersion }: PropsDescriptionArgs) => ({
+    name: 'circularProgressProps',
+    description: `Props forwarded to the [CircularProgress](${ExternalLinks.muiComponents.circularProgress(muiVersion)}) displayed in the autocomplete input when it is \`loading\`. Added in \`v4.3\`.`,
+    type: `[CircularProgressProps](${ExternalLinks.muiComponentApi.circularProgress(muiVersion)})`,
+    hasLinkInType: true
+  }),
   hideSelectAllOption_MultiAutocomplete: {
     name: 'hideSelectAllOption',
     description:
@@ -773,10 +797,16 @@ const PropsDescription: Record<
     description: 'Allows users to enter values that are not present in the autocomplete options. Supported from v4 onwards.',
     type: 'boolean'
   },
+  countrySelectProps: ({ muiVersion }: PropsDescriptionArgs) => ({
+    name: 'countrySelectProps',
+    description: `Props forwarded to the internal [Select](${ExternalLinks.muiComponents.select(muiVersion)}}) that renders the flag/dial-code trigger and country dropdown. Added in \`v4.3\`.`,
+    type: `[SelectProps](${ExternalLinks.muiComponentApi.select(muiVersion)})`,
+    hasLinkInType: true
+  }),
   searchCountryProps: {
     name: 'searchCountryProps',
-    description: 'Props to customize the country search field and country menu item rendering',
-    type: '{ allowCountrySearch, textFieldProps, renderCountryMenuItem, noCountryFoundText }',
+    description: 'Props to customize the country search field and country menu item rendering. `menuItemProps` added in `v4.3`.',
+    type: '{ allowCountrySearch, textFieldProps, renderCountryMenuItem, noCountryFoundText, menuItemProps }',
   },
 });
 

--- a/apps/rhf-mui-docs/src/page-components/misc/RHFPhoneInput.tsx
+++ b/apps/rhf-mui-docs/src/page-components/misc/RHFPhoneInput.tsx
@@ -7,6 +7,7 @@ const RHFPhoneInputPropsTable = ({
   docsVersion,
   muiVersion,
   v1,
+  v3AndAbove,
   v4AndAbove
 }: VersionProps) => {
   const valueChangeProps = v4AndAbove
@@ -33,6 +34,12 @@ const RHFPhoneInputPropsTable = ({
         LegacyPropsDescription.value_PhoneInput,
         LegacyPropsDescription.label_v1
       ]),
+    ...(v4AndAbove
+      ? [getPropDetailsByVersion(PropsDescription.countrySelectProps, { muiVersion })]
+      : v3AndAbove
+        ? [getPropDetailsByVersion(LegacyPropsDescription.countrySelectProps_v3, { muiVersion })]
+        : []
+    ),
     getPropDetailsByVersion(PropsDescription.showLabelAboveFormField, {
       muiVersion
     }),

--- a/apps/rhf-mui-docs/src/page-components/mui/autocomplete/RHFAutocomplete.tsx
+++ b/apps/rhf-mui-docs/src/page-components/mui/autocomplete/RHFAutocomplete.tsx
@@ -6,6 +6,7 @@ import { getPropDetailsByVersion } from '@site/src/utils';
 const RHFAutocompletePropsTable = ({
   docsVersion,
   muiVersion,
+  v3AndAbove,
   v4AndAbove
 }: VersionProps) => {
   const onValueChange = v4AndAbove
@@ -55,9 +56,15 @@ const RHFAutocompletePropsTable = ({
       muiVersion
     }),
     getPropDetailsByVersion(PropsDescription.textFieldProps, { muiVersion }),
+    getPropDetailsByVersion(PropsDescription.ChipProps_Autocomplete, { muiVersion }),
+    ...(v4AndAbove
+      ? [getPropDetailsByVersion(PropsDescription.circularProgressProps_Autocompletes, { muiVersion })]
+      : v3AndAbove
+        ? [getPropDetailsByVersion(LegacyPropsDescription.circularProgressProps_Autocompletes_v3, { muiVersion })]
+        : []
+    ),
     ...(v4AndAbove
       ? [
-        getPropDetailsByVersion(PropsDescription.ChipProps_Autocomplete, { muiVersion }),
         PropsDescription.customIds
       ]
       : []

--- a/apps/rhf-mui-docs/src/page-components/mui/autocomplete/RHFAutocompleteObject.tsx
+++ b/apps/rhf-mui-docs/src/page-components/mui/autocomplete/RHFAutocompleteObject.tsx
@@ -6,7 +6,8 @@ import { getPropDetailsByVersion } from '@site/src/utils';
 const RHFAutocompleteObjectPropsTable = ({
   docsVersion,
   muiVersion,
-  v4AndAbove
+  v3AndAbove,
+  v4AndAbove,
 }: VersionProps) => {
   const onValueChange = v4AndAbove
     ? [
@@ -51,6 +52,13 @@ const RHFAutocompleteObjectPropsTable = ({
       muiVersion
     }),
     getPropDetailsByVersion(PropsDescription.textFieldProps, { muiVersion }),
+    getPropDetailsByVersion(PropsDescription.ChipProps_Autocomplete, { muiVersion }),
+    ...(v4AndAbove
+      ? [getPropDetailsByVersion(PropsDescription.circularProgressProps_Autocompletes, { muiVersion })]
+      : v3AndAbove
+        ? [getPropDetailsByVersion(LegacyPropsDescription.circularProgressProps_Autocompletes_v3, { muiVersion })]
+        : []
+    ),
     ...(v4AndAbove ? [PropsDescription.customIds] : [])
   ];
 

--- a/apps/rhf-mui-docs/src/page-components/mui/autocomplete/RHFMultiAutocomplete.tsx
+++ b/apps/rhf-mui-docs/src/page-components/mui/autocomplete/RHFMultiAutocomplete.tsx
@@ -62,6 +62,13 @@ const RHFMultiAutocompletePropsTable = ({
     }),
     getPropDetailsByVersion(PropsDescription.textFieldProps, { muiVersion }),
     getPropDetailsByVersion(PropsDescription.ChipProps_Autocomplete, { muiVersion }),
+    getPropDetailsByVersion(PropsDescription.ChipProps_Autocomplete, { muiVersion }),
+    ...(v4AndAbove
+      ? [getPropDetailsByVersion(PropsDescription.circularProgressProps_Autocompletes, { muiVersion })]
+      : v3AndAbove
+        ? [getPropDetailsByVersion(LegacyPropsDescription.circularProgressProps_Autocompletes_v3, { muiVersion })]
+        : []
+    ),
     ...(v4AndAbove ? [PropsDescription.customIds] : [])
   ];
 

--- a/apps/rhf-mui-docs/src/page-components/mui/autocomplete/RHFMultiAutocompleteObject.tsx
+++ b/apps/rhf-mui-docs/src/page-components/mui/autocomplete/RHFMultiAutocompleteObject.tsx
@@ -4,9 +4,10 @@ import { type PropsInfo, type VersionProps } from '@site/src/types';
 import { getPropDetailsByVersion } from '@site/src/utils';
 
 const RHFMultiAutocompleteObjectPropsTable = ({
-  v4AndAbove,
   docsVersion,
-  muiVersion
+  muiVersion,
+  v3AndAbove,
+  v4AndAbove
 }: VersionProps) => {
   const onValueChange = v4AndAbove
     ? [
@@ -60,6 +61,13 @@ const RHFMultiAutocompleteObjectPropsTable = ({
     }),
     getPropDetailsByVersion(PropsDescription.textFieldProps, { muiVersion }),
     getPropDetailsByVersion(PropsDescription.ChipProps_Autocomplete, { muiVersion }),
+    getPropDetailsByVersion(PropsDescription.ChipProps_Autocomplete, { muiVersion }),
+    ...(v4AndAbove
+      ? [getPropDetailsByVersion(PropsDescription.circularProgressProps_Autocompletes, { muiVersion })]
+      : v3AndAbove
+        ? [getPropDetailsByVersion(LegacyPropsDescription.circularProgressProps_Autocompletes_v3, { muiVersion })]
+        : []
+    ),
     ...(v4AndAbove ? [PropsDescription.customIds] : [])
   ];
 

--- a/apps/rhf-mui-docs/src/page-components/mui/inputs/RHFPasswordInput.tsx
+++ b/apps/rhf-mui-docs/src/page-components/mui/inputs/RHFPasswordInput.tsx
@@ -46,6 +46,12 @@ const RHFPasswordInputPropsTable = ({
     PropsDescription.showPasswordIcon,
     PropsDescription.hidePasswordIcon,
     ...(v4AndAbove
+      ? [getPropDetailsByVersion(PropsDescription.iconButtonProps_PasswordInput, { muiVersion })]
+      : v3AndAbove
+        ? [getPropDetailsByVersion(LegacyPropsDescription.iconButtonProps_PasswordInput_v3, { muiVersion })]
+        : []
+    ),
+    ...(v4AndAbove
       ? [PropsDescription.renderError]
       : [getPropDetailsByVersion(LegacyPropsDescription.errorMessage, { muiVersion })]
     ),

--- a/apps/rhf-mui-docs/src/page-components/mui/select/RHFSelect.tsx
+++ b/apps/rhf-mui-docs/src/page-components/mui/select/RHFSelect.tsx
@@ -45,6 +45,12 @@ const RHFSelectPropsTable = ({
       docsVersion,
       muiVersion
     }),
+    ...(v4AndAbove
+      ? [getPropDetailsByVersion(PropsDescription.inputLabelProps_Select, { muiVersion })]
+      : v3AndAbove
+        ? [getPropDetailsByVersion(LegacyPropsDescription.inputLabelProps_Select_v3, { muiVersion })]
+        : []
+    ),
     getPropDetailsByVersion(PropsDescription.showLabelAboveFormField, {
       muiVersion
     }),
@@ -56,6 +62,12 @@ const RHFSelectPropsTable = ({
       ? [getPropDetailsByVersion(PropsDescription.hideLabel, { muiVersion })]
       : []),
     ...(v3AndAbove ? [PropsDescription.placeholder_Select] : []),
+    ...(v4AndAbove
+      ? [getPropDetailsByVersion(PropsDescription.menuItemProps_Select, { muiVersion })]
+      : v3AndAbove
+        ? [getPropDetailsByVersion(LegacyPropsDescription.menuItemProps_Select_v3, { muiVersion })]
+        : []
+    ),
     ...(v4AndAbove
       ? [PropsDescription.renderError]
       : [getPropDetailsByVersion(LegacyPropsDescription.errorMessage, { muiVersion })]

--- a/apps/rhf-mui-docs/versioned_docs/version-v3/components/misc/RHFPhoneInput.mdx
+++ b/apps/rhf-mui-docs/versioned_docs/version-v3/components/misc/RHFPhoneInput.mdx
@@ -66,4 +66,5 @@ and accepts the following additional props:
 <RHFPhoneInputPropsTable
   docsVersion={3}
   muiVersion={7}
+  v3AndAbove
 />

--- a/apps/rhf-mui-docs/versioned_docs/version-v3/components/mui/RHFAutocomplete.mdx
+++ b/apps/rhf-mui-docs/versioned_docs/version-v3/components/mui/RHFAutocomplete.mdx
@@ -71,4 +71,5 @@ and accepts the following additional props:
 <RHFAutocompletePropsTable
   docsVersion={3}
   muiVersion={7}
+  v3AndAbove
 />

--- a/apps/rhf-mui-docs/versioned_docs/version-v3/components/mui/RHFAutocompleteObject.mdx
+++ b/apps/rhf-mui-docs/versioned_docs/version-v3/components/mui/RHFAutocompleteObject.mdx
@@ -7,9 +7,8 @@ description: Autocomplete component that returns full option objects instead of 
 
 import { RHFAutocompleteObjectPropsTable } from '@site/src/page-components';
 import { AvailabilityBanner } from '@site/src/components';
-import NewImg from '@site/static/img/new.png';
 
-# RHFAutocompleteObject<sup><img src={NewImg} alt="NEW" height="40" /></sup>
+# RHFAutocompleteObject
 
 <AvailabilityBanner componentName="RHFAutocompleteObject" version="3.3" />
 
@@ -100,4 +99,5 @@ and accepts the following additional props:
 <RHFAutocompleteObjectPropsTable
   docsVersion={3}
   muiVersion={7}
+  v3AndAbove
 />

--- a/apps/rhf-mui-docs/versioned_docs/version-v3/components/mui/RHFMultiAutocompleteObject.mdx
+++ b/apps/rhf-mui-docs/versioned_docs/version-v3/components/mui/RHFMultiAutocompleteObject.mdx
@@ -7,9 +7,8 @@ description: Multi-select autocomplete component with object-based values and bu
 
 import { RHFMultiAutocompleteObjectPropsTable } from '@site/src/page-components';
 import { AvailabilityBanner } from '@site/src/components';
-import NewImg from '@site/static/img/new.png';
 
-# RHFMultiAutocompleteObject<sup><img src={NewImg} alt="NEW" height="40" /></sup>
+# RHFMultiAutocompleteObject
 
 <AvailabilityBanner componentName="RHFMultiAutocompleteObject" version="3.3" />
 
@@ -78,4 +77,5 @@ and accepts the following additional props:
 <RHFMultiAutocompleteObjectPropsTable
   docsVersion={3}
   muiVersion={7}
+  v3AndAbove
 />

--- a/changelog/v3.md
+++ b/changelog/v3.md
@@ -1,5 +1,20 @@
 # Changelog - v3
 
+## [3.7.0](https://github.com/nishkohli96/rhf-mui-components/tree/v3.7.0)
+
+**Released - 7 August, 2026**
+
+### ✨ Enhancements
+- Exposed previously-unreachable internal sub-component props:
+  - `RHFPasswordInput`: `iconButtonProps` for the show/hide toggle button.
+  - `RHFSelect`: `menuItemProps` (every option `MenuItem`) and `inputLabelProps` (the inline `InputLabel`).
+  - `RHFAutocomplete`, `RHFAutocompleteObject`, `RHFMultiAutocomplete`, `RHFMultiAutocompleteObject`: `circularProgressProps` for the loading spinner.
+  - `RHFPhoneInput`: `countrySelectProps` for the flag/dial-code trigger `Select`.
+
+### 🐞 Bug Fixes
+- `RHFSelect`: Forward `disabled` prop to `InputLabel` when the field is disabled.
+
+
 ## [3.6.1](https://github.com/nishkohli96/rhf-mui-components/tree/v3.6.1)
 
 **Released - 4 August, 2026**

--- a/changelog/v4.md
+++ b/changelog/v4.md
@@ -1,5 +1,22 @@
 # Changelog - v4
 
+## [4.3.0](https://github.com/nishkohli96/rhf-mui-components/tree/v4.3.0)
+
+### ✨ Enhancements
+- Exposed previously-unreachable internal sub-component props:
+  - `RHFPasswordInput`: `iconButtonProps` for the show/hide toggle button.
+  - `RHFSelect`: `menuItemProps` (every option `MenuItem`) and `inputLabelProps` (the inline `InputLabel`).
+  - `RHFAutocomplete`, `RHFAutocompleteObject`, `RHFMultiAutocomplete`, `RHFMultiAutocompleteObject`: `circularProgressProps` for the loading spinner.
+  - `RHFPhoneInput`: `countrySelectProps` for the flag/dial-code trigger `Select`, and `searchCountryProps.menuItemProps` for every country `MenuItem`.
+
+### 🐞 Bug Fixes
+- `RHFNumberInput`: Set `slotProps.htmlInput.step` to `any` (except for `onlyIntegers`) for decimal inputs (was reusing `resolvedStepAmount`), preventing false "stepMismatch" validation errors on values like 23.45.
+- `RHFPhoneInput`
+  - Fix country dropdown scrollbar spanning full menu height alongside sticky search field; scroll region now starts below it.
+  - Removed `multiple` and `multiline` from `countrySelectProps`; both are always `false`.
+  - Fixed a console warning ("out-of-range value") and a brief mispositioned flash when selecting a country while the search filter was active — every country now stays mounted as a `MenuItem` (hidden via CSS instead of removed) so the selected value always has a matching option.
+
+
 ## [4.2.2](https://github.com/nishkohli96/rhf-mui-components/tree/v4.2.2)
 
 **Released — 4 August, 2026**

--- a/changelog/v4.md
+++ b/changelog/v4.md
@@ -2,6 +2,9 @@
 
 ## [4.3.0](https://github.com/nishkohli96/rhf-mui-components/tree/v4.3.0)
 
+### 📖 Docs
+- Updated  `v3` and `v4` documentation for components that received new props.
+
 ### ✨ Enhancements
 - Exposed previously-unreachable internal sub-component props:
   - `RHFPasswordInput`: `iconButtonProps` for the show/hide toggle button.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-components-root",
-  "version": "4.2.2",
+  "version": "4.3.0",
   "description": "A suite of 25+ production-ready react-hook-form components built with material-ui. Fully typed, tree-shakable, and optimized for enterprise-grade forms.",
   "author": "Nishant Kohli",
   "private": true,

--- a/packages/rhf-mui-components/package.json
+++ b/packages/rhf-mui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-components",
-  "version": "4.2.2",
+  "version": "4.3.0",
   "description": "A suite of 25+ production-ready react-hook-form components built with material-ui. Fully typed, tree-shakable, and optimized for enterprise-grade forms.",
   "author": "Nishant Kohli",
   "homepage": "https://rhf-mui-components.vercel.app/",
@@ -16,7 +16,7 @@
   "type": "module",
   "sideEffects": false,
   "dependencies": {
-    "@nish1896/mui-components": "^1.0.5"
+    "@nish1896/mui-components": "^1.1.1"
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-core": "43.3.0",

--- a/packages/rhf-mui-components/src/common/types/mui.ts
+++ b/packages/rhf-mui-components/src/common/types/mui.ts
@@ -1,11 +1,15 @@
 import type { FormLabelProps as MuiFormLabelProps } from '@mui/material/FormLabel';
 import type { FormControlLabelProps as MuiFormControlLabelProps } from '@mui/material/FormControlLabel';
 import type { FormHelperTextProps as MuiFormHelperTextProps } from '@mui/material/FormHelperText';
+import type { TextFieldProps as MuiTextFieldProps } from '@mui/material/TextField';
+import type { SelectProps as MuiSelectProps } from '@mui/material/Select';
+import type { MenuItemProps as MuiMenuItemProps } from '@mui/material/MenuItem';
+import type { InputLabelProps as MuiInputLabelProps } from '@mui/material/InputLabel';
 import type { CheckboxProps as MuiCheckboxProps } from '@mui/material/Checkbox';
 import type { RadioProps as MuiRadioProps } from '@mui/material/Radio';
-import type { SelectProps as MuiSelectProps } from '@mui/material/Select';
-import type { TextFieldProps as MuiTextFieldProps } from '@mui/material/TextField';
+import type { IconButtonProps as MuiIconButtonProps } from '@mui/material/IconButton';
 import type { ChipProps } from '@mui/material/Chip';
+import type { CircularProgressProps as MuiCircularProgressProps } from '@mui/material/CircularProgress';
 
 export type FormLabelProps = Omit<
   MuiFormLabelProps,
@@ -44,20 +48,6 @@ export type TextFieldProps = Omit<
   | 'ref'
 >;
 
-export type CheckboxProps = Omit<
-  MuiCheckboxProps,
-  | 'name'
-  | 'value'
-  | 'checked'
-  | 'defaultChecked'
-  | 'onChange'
->;
-
-export type RadioProps = Omit<
-  MuiRadioProps,
-  | 'checked'
->;
-
 export type SelectProps = Omit<
   MuiSelectProps,
   | 'name'
@@ -70,6 +60,23 @@ export type SelectProps = Omit<
   | 'ref'
   | 'displayEmpty'
   | 'multiple'
+>;
+
+export type MenuItemProps = Omit<
+  MuiMenuItemProps,
+  | 'key'
+  | 'value'
+  | 'disabled'
+  | 'children'
+>;
+
+export type InputLabelProps = Omit<
+  MuiInputLabelProps,
+  | 'id'
+  | 'htmlFor'
+  | 'shrink'
+  | 'disabled'
+  | 'children'
 >;
 
 export type AutoCompleteTextFieldProps = Omit<
@@ -100,6 +107,31 @@ export type OmittedAutocompleteProps
     | 'autoHighlight'
     | 'disableCloseOnSelect';
 
+export type CheckboxProps = Omit<
+  MuiCheckboxProps,
+  | 'name'
+  | 'value'
+  | 'checked'
+  | 'defaultChecked'
+  | 'onChange'
+>;
+
+export type RadioProps = Omit<
+  MuiRadioProps,
+  | 'checked'
+>;
+
+export type IconButtonProps = Omit<
+  MuiIconButtonProps,
+  | 'type'
+  | 'onClick'
+  | 'onMouseDown'
+  | 'edge'
+  | 'disabled'
+  | 'aria-label'
+  | 'children'
+>;
+
 export type MuiChipProps = Omit<
   ChipProps,
   | 'key'
@@ -107,3 +139,5 @@ export type MuiChipProps = Omit<
   | 'onDelete'
   | 'disabled'
 >;
+
+export type CircularProgressProps = MuiCircularProgressProps;

--- a/packages/rhf-mui-components/src/misc/phone-input/index.tsx
+++ b/packages/rhf-mui-components/src/misc/phone-input/index.tsx
@@ -21,15 +21,17 @@ import {
   type RegisterOptions
 } from 'react-hook-form';
 import { type TextFieldProps } from '@mui/material/TextField';
+import { type SelectProps as MuiSelectProps } from '@mui/material/Select';
+import MUIPhoneInput from '@nish1896/mui-components/misc/phone-input';
 import {
   type CountryIso2,
   type ParsedCountry,
   type UsePhoneInputConfig
 } from 'react-international-phone';
-import MUIPhoneInput from '@nish1896/mui-components/misc/phone-input';
 import {
   type FormLabelProps,
-  type FormHelperTextProps
+  type FormHelperTextProps,
+  type MenuItemProps
 } from '@/common';
 import { RHFMuiConfigContext } from '@/config/ConfigProvider';
 import type { CustomComponentIds } from '@/types';
@@ -106,9 +108,30 @@ type SearchCountryProps = {
    * @default 'No countries found'
    */
   noCountryFoundText?: string;
+  /**
+   * Props forwarded to every rendered country `MenuItem` — including the
+   * disabled "no results" item shown when `noCountryFoundText` applies.
+   *
+   * Added in `v4.3`.
+   */
+  menuItemProps?: MenuItemProps;
 };
 
 type PhoneInputProps = Omit<UsePhoneInputConfig, 'value' | 'onChange'>;
+
+type CountrySelectProps = Omit<
+  MuiSelectProps,
+  | 'value'
+  | 'defaultValue'
+  | 'onChange'
+  | 'onOpen'
+  | 'onClose'
+  | 'renderValue'
+  | 'MenuProps'
+  | 'disabled'
+  | 'children'
+  | 'ref'
+>;
 
 export type RHFPhoneInputProps<T extends FieldValues> = {
   /**
@@ -159,6 +182,12 @@ export type RHFPhoneInputProps<T extends FieldValues> = {
    */
   searchCountryProps?: SearchCountryProps;
   /**
+   * Props forwarded to the internal `Select` that renders the flag/dial-code
+   * trigger and country dropdown — e.g. a custom `size` or `sx` (merged with
+   * the component's own).
+   */
+  countrySelectProps?: CountrySelectProps;
+  /**
    * When `true`, renders the label above the component instead of within the field layout.
    */
   showLabelAboveFormField?: boolean;
@@ -205,6 +234,7 @@ const RHFPhoneInputInner = forwardRef(function RHFPhoneInput<
     onBlur: muiOnBlur,
     phoneInputProps,
     searchCountryProps,
+    countrySelectProps,
     label,
     showLabelAboveFormField,
     formLabelProps,
@@ -282,6 +312,7 @@ const RHFPhoneInputInner = forwardRef(function RHFPhoneInput<
             disabled={isDisabled}
             phoneInputProps={phoneInputProps}
             searchCountryProps={searchCountryProps}
+            countrySelectProps={countrySelectProps}
             label={label}
             showLabelAboveFormField={isLabelAboveFormField}
             formLabelProps={{

--- a/packages/rhf-mui-components/src/mui/autocomplete-object/index.tsx
+++ b/packages/rhf-mui-components/src/mui/autocomplete-object/index.tsx
@@ -208,8 +208,8 @@ export type RHFAutocompleteObjectProps<
    */
   textFieldProps?: AutoCompleteTextFieldProps;
   /**
-   * Props forwarded to the internal MUI `CircularProgress` shown in the input
-   * while `loading` is true.
+   * Props forwarded to the `CircularProgress` shown in the input
+   * while `loading` is `true`.
    */
   circularProgressProps?: CircularProgressProps;
   /**

--- a/packages/rhf-mui-components/src/mui/autocomplete-object/index.tsx
+++ b/packages/rhf-mui-components/src/mui/autocomplete-object/index.tsx
@@ -28,6 +28,7 @@ import {
   type FormHelperTextProps,
   type AutoCompleteTextFieldProps,
   type MuiChipProps,
+  type CircularProgressProps,
   type CustomOnChangeProps
 } from '@/common';
 import { RHFMuiConfigContext } from '@/config/ConfigProvider';
@@ -207,6 +208,11 @@ export type RHFAutocompleteObjectProps<
    */
   textFieldProps?: AutoCompleteTextFieldProps;
   /**
+   * Props forwarded to the internal MUI `CircularProgress` shown in the input
+   * while `loading` is true.
+   */
+  circularProgressProps?: CircularProgressProps;
+  /**
    * Props forwarded to chips rendered for selected values.
    */
   ChipProps?: MuiChipProps;
@@ -258,6 +264,7 @@ const RHFAutocompleteObjectInner = forwardRef(function RHFAutocompleteObject<
   slotProps,
   ChipProps,
   loading,
+  circularProgressProps,
   limitTags,
   getLimitTagsText,
   customIds,
@@ -356,6 +363,7 @@ ref: Ref<HTMLInputElement>) {
             slotProps={slotProps}
             ChipProps={ChipProps}
             loading={loading}
+            circularProgressProps={circularProgressProps}
             limitTags={limitTags}
             getLimitTagsText={getLimitTagsText}
             customIds={customIds}

--- a/packages/rhf-mui-components/src/mui/autocomplete/index.tsx
+++ b/packages/rhf-mui-components/src/mui/autocomplete/index.tsx
@@ -28,6 +28,7 @@ import {
   type FormHelperTextProps,
   type AutoCompleteTextFieldProps,
   type MuiChipProps,
+  type CircularProgressProps,
   type AutocompleteNewValue,
   type CustomOnChangeProps
 } from '@/common';
@@ -235,6 +236,11 @@ export type RHFAutocompleteProps<
    */
   textFieldProps?: AutoCompleteTextFieldProps;
   /**
+   * Props forwarded to the internal MUI `CircularProgress` shown in the input
+   * while `loading` is true.
+   */
+  circularProgressProps?: CircularProgressProps;
+  /**
    * Props forwarded to chips rendered for selected values.
    */
   ChipProps?: MuiChipProps;
@@ -269,8 +275,10 @@ const RHFAutocompleteInner = forwardRef(function RHFAutocomplete<
   disableClearable,
   freeSolo,
   autoHighlight,
-  onValueChange,
   customOnChange,
+  onValueChange,
+  onFocus: muiOnFocus,
+  onBlur: muiOnBlur,
   disabled: muiDisabled,
   label,
   showLabelAboveFormField,
@@ -285,9 +293,8 @@ const RHFAutocompleteInner = forwardRef(function RHFAutocomplete<
   textFieldProps,
   slotProps,
   ChipProps,
-  onFocus: muiOnFocus,
-  onBlur: muiOnBlur,
   loading,
+  circularProgressProps,
   limitTags,
   customIds,
   autoSelect,
@@ -401,6 +408,7 @@ ref: Ref<HTMLInputElement>) {
             slotProps={slotProps}
             ChipProps={ChipProps}
             loading={loading}
+            circularProgressProps={circularProgressProps}
             limitTags={limitTags}
             autoSelect={autoSelect}
             getLimitTagsText={getLimitTagsText}

--- a/packages/rhf-mui-components/src/mui/autocomplete/index.tsx
+++ b/packages/rhf-mui-components/src/mui/autocomplete/index.tsx
@@ -236,8 +236,8 @@ export type RHFAutocompleteProps<
    */
   textFieldProps?: AutoCompleteTextFieldProps;
   /**
-   * Props forwarded to the internal MUI `CircularProgress` shown in the input
-   * while `loading` is true.
+   * Props forwarded to the `CircularProgress` shown in the input
+   * while `loading` is `true`.
    */
   circularProgressProps?: CircularProgressProps;
   /**

--- a/packages/rhf-mui-components/src/mui/multi-autocomplete-object/index.tsx
+++ b/packages/rhf-mui-components/src/mui/multi-autocomplete-object/index.tsx
@@ -28,6 +28,7 @@ import {
   type FormHelperTextProps,
   type AutoCompleteTextFieldProps,
   type MuiChipProps,
+  type CircularProgressProps,
   type CustomOnChangeProps
 } from '@/common';
 import { RHFMuiConfigContext } from '@/config/ConfigProvider';
@@ -209,6 +210,11 @@ export type RHFMultiAutocompleteObjectProps<
    */
   textFieldProps?: AutoCompleteTextFieldProps;
   /**
+   * Props forwarded to the internal MUI `CircularProgress` shown in the input
+   * while `loading` is true.
+   */
+  circularProgressProps?: CircularProgressProps;
+  /**
    * Props forwarded to chips rendered for selected values.
    */
   ChipProps?: MuiChipProps;
@@ -243,6 +249,7 @@ const RHFMultiAutocompleteObjectInner = forwardRef(function RHFMultiAutocomplete
   hideSelectAllOption,
   customOnChange,
   onValueChange,
+  onBlur: muiOnBlur,
   disabled: muiDisabled,
   label,
   showLabelAboveFormField,
@@ -260,8 +267,8 @@ const RHFMultiAutocompleteObjectInner = forwardRef(function RHFMultiAutocomplete
   textFieldProps,
   slotProps,
   ChipProps,
-  onBlur: muiOnBlur,
   loading,
+  circularProgressProps,
   customIds,
   getOptionDisabled,
   limitTags,
@@ -363,6 +370,7 @@ ref: Ref<HTMLInputElement>): JSX.Element {
               muiOnBlur?.(blurEvent);
             }}
             loading={loading}
+            circularProgressProps={circularProgressProps}
             customIds={customIds}
             getOptionDisabled={getOptionDisabled}
             limitTags={limitTags}

--- a/packages/rhf-mui-components/src/mui/multi-autocomplete-object/index.tsx
+++ b/packages/rhf-mui-components/src/mui/multi-autocomplete-object/index.tsx
@@ -210,8 +210,8 @@ export type RHFMultiAutocompleteObjectProps<
    */
   textFieldProps?: AutoCompleteTextFieldProps;
   /**
-   * Props forwarded to the internal MUI `CircularProgress` shown in the input
-   * while `loading` is true.
+   * Props forwarded to the `CircularProgress` shown in the input
+   * while `loading` is `true`.
    */
   circularProgressProps?: CircularProgressProps;
   /**

--- a/packages/rhf-mui-components/src/mui/multi-autocomplete/index.tsx
+++ b/packages/rhf-mui-components/src/mui/multi-autocomplete/index.tsx
@@ -27,6 +27,7 @@ import {
   type FormHelperTextProps,
   type AutoCompleteTextFieldProps,
   type MuiChipProps,
+  type CircularProgressProps,
   type CustomOnChangeProps
 } from '@/common';
 import { RHFMuiConfigContext } from '@/config/ConfigProvider';
@@ -220,6 +221,11 @@ export type RHFMultiAutocompleteProps<
    */
   textFieldProps?: AutoCompleteTextFieldProps;
   /**
+   * Props forwarded to the internal MUI `CircularProgress` shown in the input
+   * while `loading` is true.
+   */
+  circularProgressProps?: CircularProgressProps;
+  /**
    * Props forwarded to chips rendered for selected values.
    */
   ChipProps?: MuiChipProps;
@@ -275,6 +281,7 @@ const RHFMultiAutocompleteInner = forwardRef(function RHFMultiAutocomplete<
   slotProps,
   ChipProps,
   loading,
+  circularProgressProps,
   customIds,
   getOptionDisabled,
   limitTags,
@@ -385,6 +392,7 @@ ref: Ref<HTMLInputElement>) {
             selectAllText={selectAllText}
             hideSelectAllOption={hideSelectAllOption}
             loading={loading}
+            circularProgressProps={circularProgressProps}
             customIds={customIds}
             getOptionDisabled={getOptionDisabled}
             limitTags={limitTags}

--- a/packages/rhf-mui-components/src/mui/multi-autocomplete/index.tsx
+++ b/packages/rhf-mui-components/src/mui/multi-autocomplete/index.tsx
@@ -221,8 +221,8 @@ export type RHFMultiAutocompleteProps<
    */
   textFieldProps?: AutoCompleteTextFieldProps;
   /**
-   * Props forwarded to the internal MUI `CircularProgress` shown in the input
-   * while `loading` is true.
+   * Props forwarded to the `CircularProgress` shown in the input
+   * while `loading` is `true`.
    */
   circularProgressProps?: CircularProgressProps;
   /**

--- a/packages/rhf-mui-components/src/mui/password-input/index.tsx
+++ b/packages/rhf-mui-components/src/mui/password-input/index.tsx
@@ -22,6 +22,7 @@ import {
   type FormLabelProps,
   type FormHelperTextProps,
   type TextFieldProps,
+  type IconButtonProps,
   type CustomOnChangeProps
 } from '@/common';
 import { RHFMuiConfigContext } from '@/config/ConfigProvider';
@@ -118,6 +119,12 @@ export type RHFPasswordInputProps<T extends FieldValues> = {
    */
   hidePasswordIcon?: ReactNode;
   /**
+   * Props forwarded to the `IconButton` component that toggles password
+   * visibility. Use `showPasswordIcon`/`hidePasswordIcon` to swap the icon
+   * itself; this is for the button around it — e.g. a custom `size` or `sx`.
+   */
+  iconButtonProps?: IconButtonProps;
+  /**
    * When true, the value is displayed but cannot be edited.
    *
    * Unlike `disabled`, the field stays focusable, is still submitted with the
@@ -171,6 +178,7 @@ const RHFPasswordInputInner = forwardRef(function RHFPasswordInput<
   hideLabel,
   showPasswordIcon,
   hidePasswordIcon,
+  iconButtonProps,
   readOnly,
   required,
   errorMessage,
@@ -258,6 +266,7 @@ ref: Ref<HTMLInputElement>) {
             hideLabel={hideLabel}
             showPasswordIcon={showPasswordIcon}
             hidePasswordIcon={hidePasswordIcon}
+            iconButtonProps={iconButtonProps}
             readOnly={readOnly}
             required={isFieldRequired}
             errorMessage={fieldErrorMessage}

--- a/packages/rhf-mui-components/src/mui/select/index.tsx
+++ b/packages/rhf-mui-components/src/mui/select/index.tsx
@@ -21,6 +21,8 @@ import {
   type FormLabelProps,
   type FormHelperTextProps,
   type SelectProps,
+  type MenuItemProps,
+  type InputLabelProps,
   type CustomOnChangeProps,
   type OptionValue,
   type OptionRenderState
@@ -93,48 +95,6 @@ export type RHFSelectProps<
    */
   valueKey?: ValueKey;
   /**
-   * Custom renderer for dropdown options.
-   *
-   * Use this prop to customize the label for each option in the `MenuItem` component.
-   * When not provided, the option label derived from `labelKey` (or the
-   * option value itself for primitive options) is rendered.
-   *
-   * @param option - The option being rendered.
-   * @param state - Current status of the option (`disabled`, `selected`), so the
-   *   label can react to it — e.g. dim a disabled option.
-   * @returns Custom React content to display for the option.
-   */
-  renderOptionLabel?: (option: Option, state: OptionRenderState) => ReactNode;
-  /**
-   * Function to dynamically disable specific option(s).
-   *
-   * Return `true` to disable the option and prevent it from being selected.
-   *
-   * @param option - The option being evaluated.
-   */
-  getOptionDisabled?: (option: Option) => boolean;
-  /**
-   * When true, allows selecting multiple values.
-   */
-  multiple?: Multiple;
-  /**
-   * When `true`, displays a default placeholder option at the top of the
-   * dropdown menu.
-   *
-   * The option uses an empty string (`''`) as its value and is automatically
-   * disabled when the field is marked as required.
-   *
-   * @default false
-   */
-  showDefaultOption?: boolean;
-  /**
-   * Custom text displayed for the default option when
-   * `showDefaultOption` is enabled.
-   *
-   * @default `Select ${fieldLabel}`
-   */
-  defaultOptionText?: string;
-  /**
    * Overrides the default MUI Select change handling.
    * Receives the normalized selected value, original select event, and selected child element.
    * Call `rhfOnChange` with the value that should be stored; else the form value will not be updated.
@@ -168,6 +128,61 @@ export type RHFSelectProps<
     event,
     child
   }: OnValueChangeProps<Option, ValueKey, Multiple>) => void;
+  /**
+   * When true, allows selecting multiple values.
+   */
+  multiple?: Multiple;
+  /**
+   * Props forwarded to each internal MUI `MenuItem`, applied to every rendered
+   * option — including the default placeholder option when `showDefaultOption`
+   * is enabled. Useful for a custom `dense`, `divider` or `sx` across all options.
+   */
+  menuItemProps?: MenuItemProps;
+  /**
+   * Custom renderer for dropdown options.
+   *
+   * Use this prop to customize the label for each option in the `MenuItem` component.
+   * When not provided, the option label derived from `labelKey` (or the
+   * option value itself for primitive options) is rendered.
+   *
+   * @param option - The option being rendered.
+   * @param state - Current status of the option (`disabled`, `selected`), so the
+   *   label can react to it — e.g. dim a disabled option.
+   * @returns Custom React content to display for the option.
+   */
+  renderOptionLabel?: (option: Option, state: OptionRenderState) => ReactNode;
+  /**
+   * Function to dynamically disable specific option(s).
+   *
+   * Return `true` to disable the option and prevent it from being selected.
+   *
+   * @param option - The option being evaluated.
+   */
+  getOptionDisabled?: (option: Option) => boolean;
+  /**
+   * When `true`, displays a default placeholder option at the top of the
+   * dropdown menu.
+   *
+   * The option uses an empty string (`''`) as its value and is automatically
+   * disabled when the field is marked as required.
+   *
+   * @default false
+   */
+  showDefaultOption?: boolean;
+  /**
+   * Custom text displayed for the default option when
+   * `showDefaultOption` is enabled.
+   *
+   * @default `Select ${fieldLabel}`
+   */
+  defaultOptionText?: string;
+  /**
+   * Props forwarded to the `InputLabel` — the inline label shown inside
+   * the field's outline when `showLabelAboveFormField` is off. Has no
+   * effect when that label isn't rendered (`hideLabel`, `showLabelAboveFormField`,
+   * or a `placeholder` with no value selected).
+   */
+  inputLabelProps?: InputLabelProps;
   /**
    * When `true`, renders the label above the component instead of within the field layout.
    */
@@ -240,16 +255,18 @@ const RHFSelectInner = forwardRef(function RHFSelect<
     options,
     labelKey,
     valueKey,
-    renderOptionLabel,
-    getOptionDisabled,
-    multiple,
-    showDefaultOption,
-    defaultOptionText,
     customOnChange,
     onValueChange,
     onBlur: muiOnBlur,
+    multiple,
     disabled: muiDisabled,
+    menuItemProps,
+    renderOptionLabel,
+    getOptionDisabled,
+    showDefaultOption,
+    defaultOptionText,
     label,
+    inputLabelProps,
     showLabelAboveFormField,
     formLabelProps,
     hideLabel,
@@ -340,6 +357,7 @@ const RHFSelectInner = forwardRef(function RHFSelect<
               rhfOnBlur();
               muiOnBlur?.(blurEvent);
             }}
+            menuItemProps={menuItemProps}
             renderOptionLabel={renderOptionLabel}
             getOptionDisabled={getOptionDisabled}
             multiple={multiple}
@@ -347,6 +365,7 @@ const RHFSelectInner = forwardRef(function RHFSelect<
             defaultOptionText={defaultOptionText}
             disabled={isDisabled}
             label={label}
+            inputLabelProps={inputLabelProps}
             showLabelAboveFormField={isLabelAboveFormField}
             formLabelProps={{
               ...otherFormLabelProps,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -233,8 +233,8 @@ importers:
   packages/rhf-mui-components:
     dependencies:
       '@nish1896/mui-components':
-        specifier: ^1.0.5
-        version: 1.0.5(30e90968bbe39f096c7737a24290ad44)
+        specifier: ^1.1.1
+        version: 1.1.1(30e90968bbe39f096c7737a24290ad44)
     devDependencies:
       '@ckeditor/ckeditor5-core':
         specifier: 43.3.0
@@ -2828,8 +2828,8 @@ packages:
       '@eslint/js': '>=9'
       eslint: '>=9'
 
-  '@nish1896/mui-components@1.0.5':
-    resolution: {integrity: sha512-Ea0aUDl2TLozq7/CzxBUR0I7Rd/HU2xqTOTZ89PdziDSWB+VNDKPCh2KTkFHD37F6nhO7dGj5GnNC1jDJ5DmvQ==}
+  '@nish1896/mui-components@1.1.1':
+    resolution: {integrity: sha512-ODWT07EDLPjzLcIKPw7b3kXaS7aKH6c2TaJtqppCsJp2AcDl2GbuZtyXBHDniD/ZdA/uqa/0ihD8ZNLQxYw/Bw==}
     peerDependencies:
       '@mui/icons-material': ^6.0.0 || ^7.0.0
       '@mui/material': ^6.0.0 || ^7.0.0
@@ -12418,7 +12418,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@nish1896/mui-components@1.0.5(30e90968bbe39f096c7737a24290ad44)':
+  '@nish1896/mui-components@1.1.1(30e90968bbe39f096c7737a24290ad44)':
     dependencies:
       '@mui/icons-material': 7.3.11(@mui/material@7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
       '@mui/material': 7.3.11(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)


### PR DESCRIPTION
## **User description**
### 📖 Docs
- Updated  `v3` and `v4` documentation for components that received new props.

### ✨ Enhancements
- Exposed previously-unreachable internal sub-component props:
  - `RHFPasswordInput`: `iconButtonProps` for the show/hide toggle button.
  - `RHFSelect`: `menuItemProps` (every option `MenuItem`) and `inputLabelProps` (the inline `InputLabel`).
  - `RHFAutocomplete`, `RHFAutocompleteObject`, `RHFMultiAutocomplete`, `RHFMultiAutocompleteObject`: `circularProgressProps` for the loading spinner.
  - `RHFPhoneInput`: `countrySelectProps` for the flag/dial-code trigger `Select`, and `searchCountryProps.menuItemProps` for every country `MenuItem`.

### 🐞 Bug Fixes
- `RHFNumberInput`: Set `slotProps.htmlInput.step` to `any` (except for `onlyIntegers`) for decimal inputs (was reusing `resolvedStepAmount`), preventing false "stepMismatch" validation errors on values like 23.45.
- `RHFPhoneInput`
  - Fix country dropdown scrollbar spanning full menu height alongside sticky search field; scroll region now starts below it.
  - Removed `multiple` and `multiline` from `countrySelectProps`; both are always `false`.
  - Fixed a console warning ("out-of-range value") and a brief mispositioned flash when selecting a country while the search filter was active — every country now stays mounted as a `MenuItem` (hidden via CSS instead of removed) so the selected value always has a matching option.


___

## **CodeAnt-AI Description**
Customize internal controls across form components and fix input behavior issues

### What Changed
- Added customization props for password visibility buttons, select options and labels, autocomplete loading spinners, phone country selectors, and phone search menu items.
- Fixed decimal number inputs rejecting valid values through incorrect step validation.
- Fixed phone country dropdown scrolling, selection warnings, and brief layout flashes while filtering.
- Updated versioned documentation and examples to describe the new options and fixes.

### Impact
`✅ More control over form field styling`
`✅ Valid decimal values accepted`
`✅ Stable phone-country selection while searching`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
