### PR TITLE
v3.7.3 - Add JSDoc with links to docs and API reference for all components

### DIFF
--- a/apps/rhf-mui-demo/package.json
+++ b/apps/rhf-mui-demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-demo",
-  "version": "3.7.2",
+  "version": "3.7.3",
   "private": true,
   "author": "Nishant Kohli",
   "scripts": {

--- a/apps/rhf-mui-docs/package.json
+++ b/apps/rhf-mui-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-docs",
-  "version": "3.7.2",
+  "version": "3.7.3",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/changelog/v3.md
+++ b/changelog/v3.md
@@ -1,5 +1,13 @@
 # Changelog - v3
 
+## [3.7.3](https://github.com/nishkohli96/rhf-mui-components/tree/v3.7.3)
+
+**Released - 13 August, 2026**
+
+### ✨ Enhancements
+- Added component-level JSDoc summaries (with links to docs and API reference) to every `RHF*` component across the `mui`, `mui-pickers` and `misc` modules.
+
+
 ## [3.7.2](https://github.com/nishkohli96/rhf-mui-components/tree/v3.7.2)
 
 **Released - 12 August, 2026**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-components-root",
-  "version": "3.7.2",
+  "version": "3.7.3",
   "description": "A suite of 20+ production-ready react-hook-form components built with material-ui. Fully typed, tree-shakable, and optimized for enterprise-grade forms.",
   "author": "Nishant Kohli",
   "private": true,

--- a/packages/rhf-mui-components/package.json
+++ b/packages/rhf-mui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/rhf-mui-components",
-  "version": "3.7.2",
+  "version": "3.7.3",
   "description": "A suite of 20+ production-ready react-hook-form components built with material-ui. Fully typed, tree-shakable, and optimized for enterprise-grade forms.",
   "author": "Nishant Kohli",
   "homepage": "https://rhf-mui-components.vercel.app/",

--- a/packages/rhf-mui-components/src/common/constants.ts
+++ b/packages/rhf-mui-components/src/common/constants.ts
@@ -7,7 +7,7 @@
 export const defaultAutocompleteValue = 'off';
 
 /**
- * Default value for the select all option in RHFMultiAutocomplete
- * and RHFMultiAutocompleteObject components.
+ * Default value for the select all option in `RHFMultiAutocomplete`
+ * and `RHFMultiAutocompleteObject` components.
  */
 export const selectAllOptionValue = '__ALL__';

--- a/packages/rhf-mui-components/src/misc/color-picker/index.tsx
+++ b/packages/rhf-mui-components/src/misc/color-picker/index.tsx
@@ -129,6 +129,17 @@ export type RHFColorPickerProps<T extends FieldValues> = {
   formHelperTextProps?: Omit<FormHelperTextProps, 'id'>;
 };
 
+/**
+ * Controlled color picker (hue, saturation/lightness, alpha) wired to a
+ * React Hook Form field via `control`.
+ *
+ * Stores the value as a `hex` string by default, or another CSS color format
+ * via the `valueKey` prop.
+ *
+ * Docs: [RHFColorPicker](https://rhf-mui-components.vercel.app/v3/components/misc/RHFColorPicker)
+ *
+ * API: [RHFColorPickerProps](https://rhf-mui-components.vercel.app/v3/components/misc/RHFColorPicker#api)
+ */
 const RHFColorPicker = <T extends FieldValues>({
   fieldName,
   control,

--- a/packages/rhf-mui-components/src/misc/color-picker/index.tsx
+++ b/packages/rhf-mui-components/src/misc/color-picker/index.tsx
@@ -133,9 +133,8 @@ export type RHFColorPickerProps<T extends FieldValues> = {
  * Controlled color picker (hue, saturation/lightness, alpha) wired to a
  * React Hook Form field via `control`.
  *
- * Stores the value as a `hex` string by default, or another CSS color format
- * via the `valueKey` prop.
- *
+ * Stores the value as `hex`(default), `rgb` or `hsv` string.
+ * 
  * Docs: [RHFColorPicker](https://rhf-mui-components.vercel.app/v3/components/misc/RHFColorPicker)
  *
  * API: [RHFColorPickerProps](https://rhf-mui-components.vercel.app/v3/components/misc/RHFColorPicker#api)

--- a/packages/rhf-mui-components/src/misc/phone-input/index.tsx
+++ b/packages/rhf-mui-components/src/misc/phone-input/index.tsx
@@ -165,6 +165,18 @@ export type RHFPhoneInputProps<T extends FieldValues> = {
   phoneInputProps?: PhoneInputProps;
 } & InputTextFieldProps;
 
+/**
+ * Controlled `react-international-phone` input, wired to a React Hook Form
+ * field via `control`.
+ *
+ * Renders a country dropdown and, via `onValueChange`, reports
+ * structured `PhoneInputChangeReturnValue` metadata (`phone`, `inputValue` and
+ * `country`).
+ *
+ * Docs: [RHFPhoneInput](https://rhf-mui-components.vercel.app/v3/components/misc/RHFPhoneInput)
+ *
+ * API: [RHFPhoneInputProps](https://rhf-mui-components.vercel.app/v3/components/misc/RHFPhoneInput#api)
+ */
 const RHFPhoneInput = <T extends FieldValues>({
   fieldName,
   control,

--- a/packages/rhf-mui-components/src/misc/rich-text-editor/config.ts
+++ b/packages/rhf-mui-components/src/misc/rich-text-editor/config.ts
@@ -26,6 +26,14 @@ import {
 } from 'ckeditor5';
 import type { EditorConfig } from '@ckeditor/ckeditor5-core';
 
+/**
+ * Default `EditorConfig` used by `RHFRichTextEditor` when no `editorConfig`
+ * prop is passed.
+ *
+ * Bundles a fixed plugin/toolbar set (undo/redo, headings 1-6, alignment,
+ * text styling, lists, links, code blocks, tables) — override via the
+ * component's `editorConfig` prop to customize.
+ */
 export const DefaultEditorConfig: EditorConfig = {
   plugins: [
     Essentials,

--- a/packages/rhf-mui-components/src/misc/rich-text-editor/index.tsx
+++ b/packages/rhf-mui-components/src/misc/rich-text-editor/index.tsx
@@ -118,6 +118,17 @@ export type RHFRichTextEditorProps<T extends FieldValues> = {
   formHelperTextProps?: Omit<FormHelperTextProps, 'id'>;
 };
 
+/**
+ * Controlled CKEditor 5 (`ClassicEditor`) rich text field wired to a React
+ * Hook Form field via `control`, storing the value as an HTML string.
+ *
+ * Editor behavior/toolbar is customizable via `editorConfig`; init/runtime
+ * errors surface through `onError`.
+ *
+ * Docs: [RHFRichTextEditor](https://rhf-mui-components.vercel.app/v3/components/misc/RHFRichTextEditor)
+ *
+ * API: [RHFRichTextEditorProps](https://rhf-mui-components.vercel.app/v3/components/misc/RHFRichTextEditor#api)
+ */
 const RHFRichTextEditor = <T extends FieldValues>({
   fieldName,
   control,

--- a/packages/rhf-mui-components/src/mui-pickers/date-time/index.tsx
+++ b/packages/rhf-mui-components/src/mui-pickers/date-time/index.tsx
@@ -94,6 +94,17 @@ export type RHFDateTimePickerProps<T extends FieldValues> = {
   formHelperTextProps?: Omit<FormHelperTextProps, 'id'>;
 } & DateTimePickerInputProps;
 
+/**
+ * Controlled MUI X `DateTimePicker` wired to a React Hook Form field via
+ * `control`, wrapped in its own `LocalizationProvider`.
+ *
+ * Reports date-adapter validation errors (min/max/disabled dates) through
+ * `errorMessage`.
+ *
+ * Docs: [RHFDateTimePicker](https://rhf-mui-components.vercel.app/v3/components/mui-pickers/RHFDateTimePicker)
+ *
+ * API: [RHFDateTimePickerProps](https://rhf-mui-components.vercel.app/v3/components/mui-pickers/RHFDateTimePicker#api)
+ */
 const RHFDateTimePicker = <T extends FieldValues>({
   fieldName,
   control,

--- a/packages/rhf-mui-components/src/mui-pickers/date-time/index.tsx
+++ b/packages/rhf-mui-components/src/mui-pickers/date-time/index.tsx
@@ -98,9 +98,6 @@ export type RHFDateTimePickerProps<T extends FieldValues> = {
  * Controlled MUI X `DateTimePicker` wired to a React Hook Form field via
  * `control`, wrapped in its own `LocalizationProvider`.
  *
- * Reports date-adapter validation errors (min/max/disabled dates) through
- * `errorMessage`.
- *
  * Docs: [RHFDateTimePicker](https://rhf-mui-components.vercel.app/v3/components/mui-pickers/RHFDateTimePicker)
  *
  * API: [RHFDateTimePickerProps](https://rhf-mui-components.vercel.app/v3/components/mui-pickers/RHFDateTimePicker#api)

--- a/packages/rhf-mui-components/src/mui-pickers/date/index.tsx
+++ b/packages/rhf-mui-components/src/mui-pickers/date/index.tsx
@@ -98,9 +98,6 @@ export type RHFDatePickerProps<T extends FieldValues> = {
  * Controlled MUI X `DatePicker` wired to a React Hook Form field via
  * `control`, wrapped in its own `LocalizationProvider`.
  *
- * Reports date-adapter validation errors (min/max/disabled dates) through
- * `errorMessage`.
- *
  * Docs: [RHFDatePicker](https://rhf-mui-components.vercel.app/v3/components/mui-pickers/RHFDatePicker)
  *
  * API: [RHFDatePickerProps](https://rhf-mui-components.vercel.app/v3/components/mui-pickers/RHFDatePicker#api)

--- a/packages/rhf-mui-components/src/mui-pickers/date/index.tsx
+++ b/packages/rhf-mui-components/src/mui-pickers/date/index.tsx
@@ -94,6 +94,17 @@ export type RHFDatePickerProps<T extends FieldValues> = {
   formHelperTextProps?: Omit<FormHelperTextProps, 'id'>;
 } & DatePickerInputProps;
 
+/**
+ * Controlled MUI X `DatePicker` wired to a React Hook Form field via
+ * `control`, wrapped in its own `LocalizationProvider`.
+ *
+ * Reports date-adapter validation errors (min/max/disabled dates) through
+ * `errorMessage`.
+ *
+ * Docs: [RHFDatePicker](https://rhf-mui-components.vercel.app/v3/components/mui-pickers/RHFDatePicker)
+ *
+ * API: [RHFDatePickerProps](https://rhf-mui-components.vercel.app/v3/components/mui-pickers/RHFDatePicker#api)
+ */
 const RHFDatePicker = <T extends FieldValues>({
   fieldName,
   control,

--- a/packages/rhf-mui-components/src/mui-pickers/time/index.tsx
+++ b/packages/rhf-mui-components/src/mui-pickers/time/index.tsx
@@ -94,6 +94,17 @@ export type RHFTimePickerProps<T extends FieldValues> = {
   formHelperTextProps?: Omit<FormHelperTextProps, 'id'>;
 } & TimePickerInputProps;
 
+/**
+ * Controlled MUI X `TimePicker` wired to a React Hook Form field via
+ * `control`, wrapped in its own `LocalizationProvider`.
+ *
+ * Reports date-adapter validation errors (min/max/disabled times) through
+ * `errorMessage`.
+ *
+ * Docs: [RHFTimePicker](https://rhf-mui-components.vercel.app/v3/components/mui-pickers/RHFTimePicker)
+ *
+ * API: [RHFTimePickerProps](https://rhf-mui-components.vercel.app/v3/components/mui-pickers/RHFTimePicker#api)
+ */
 const RHFTimePicker = <T extends FieldValues>({
   fieldName,
   control,

--- a/packages/rhf-mui-components/src/mui-pickers/time/index.tsx
+++ b/packages/rhf-mui-components/src/mui-pickers/time/index.tsx
@@ -98,9 +98,6 @@ export type RHFTimePickerProps<T extends FieldValues> = {
  * Controlled MUI X `TimePicker` wired to a React Hook Form field via
  * `control`, wrapped in its own `LocalizationProvider`.
  *
- * Reports date-adapter validation errors (min/max/disabled times) through
- * `errorMessage`.
- *
  * Docs: [RHFTimePicker](https://rhf-mui-components.vercel.app/v3/components/mui-pickers/RHFTimePicker)
  *
  * API: [RHFTimePickerProps](https://rhf-mui-components.vercel.app/v3/components/mui-pickers/RHFTimePicker#api)

--- a/packages/rhf-mui-components/src/mui/autocomplete-object/index.tsx
+++ b/packages/rhf-mui-components/src/mui/autocomplete-object/index.tsx
@@ -181,6 +181,16 @@ export type RHFAutocompleteObjectProps<
   circularProgressProps?: CircularProgressProps;
 } & OmittedAutocompleteProps<Option, Multiple, DisableClearable>;
 
+/**
+ * Controlled MUI `Autocomplete` wired to a React Hook Form field via `control`,
+ * storing the full selected option object(s) instead of just a `valueKey`.
+ *
+ * Supports single or multiple selection through the `multiple` prop.
+ *
+ * Docs: [RHFAutocompleteObject](https://rhf-mui-components.vercel.app/v3/components/mui/RHFAutocompleteObject)
+ *
+ * API: [RHFAutocompleteObjectProps](https://rhf-mui-components.vercel.app/v3/components/mui/RHFAutocompleteObject#api)
+ */
 const RHFAutocompleteObject = <
   T extends FieldValues,
   Option extends KeyValueOption,

--- a/packages/rhf-mui-components/src/mui/autocomplete/index.tsx
+++ b/packages/rhf-mui-components/src/mui/autocomplete/index.tsx
@@ -186,6 +186,16 @@ export type RHFAutocompleteProps<
   circularProgressProps?: CircularProgressProps;
 } & OmittedAutocompleteProps<Option, Multiple, DisableClearable>;
 
+/**
+ * Controlled MUI `Autocomplete` wired to a React Hook Form field via `control`.
+ *
+ * Accepts string or object options via `labelKey`/`valueKey`,
+ * and supports single or multiple selection through the `multiple` prop.
+ *
+ * Docs: [RHFAutocomplete](https://rhf-mui-components.vercel.app/v3/components/mui/RHFAutocomplete)
+ *
+ * API: [RHFAutocompleteProps](https://rhf-mui-components.vercel.app/v3/components/mui/RHFAutocomplete#api)
+ */
 const RHFAutocomplete = <
   T extends FieldValues,
   Option extends StrObjOption,

--- a/packages/rhf-mui-components/src/mui/checkbox-group/index.tsx
+++ b/packages/rhf-mui-components/src/mui/checkbox-group/index.tsx
@@ -139,6 +139,17 @@ export type RHFCheckboxGroupProps<
   onBlur?: (event: FocusEvent<HTMLDivElement, Element>) => void;
 };
 
+/**
+ * Group of MUI `Checkbox` controls wired to a single React Hook Form array
+ * field via `control`, one checkbox per `options` entry.
+ *
+ * Best suited for up to ~10 options; use `RHFMultiAutocomplete` for larger
+ * datasets that need search.
+ *
+ * Docs: [RHFCheckboxGroup](https://rhf-mui-components.vercel.app/v3/components/mui/RHFCheckboxGroup)
+ *
+ * API: [RHFCheckboxGroupProps](https://rhf-mui-components.vercel.app/v3/components/mui/RHFCheckboxGroup#api)
+ */
 const RHFCheckboxGroup = <
   T extends FieldValues,
   Option extends StrNumObjOption = StrNumObjOption,

--- a/packages/rhf-mui-components/src/mui/checkbox/index.tsx
+++ b/packages/rhf-mui-components/src/mui/checkbox/index.tsx
@@ -74,6 +74,13 @@ export type RHFCheckboxProps<T extends FieldValues> = {
   formHelperTextProps?: Omit<FormHelperTextProps, 'id'>;
 } & CheckboxProps;
 
+/**
+ * Controlled MUI `Checkbox` wired to a React Hook Form boolean field via `control`.
+ *
+ * Docs: [RHFCheckbox](https://rhf-mui-components.vercel.app/v3/components/mui/RHFCheckbox)
+ *
+ * API: [RHFCheckboxProps](https://rhf-mui-components.vercel.app/v3/components/mui/RHFCheckbox#api)
+ */
 const RHFCheckbox = <T extends FieldValues>({
   fieldName,
   control,

--- a/packages/rhf-mui-components/src/mui/country-select/index.tsx
+++ b/packages/rhf-mui-components/src/mui/country-select/index.tsx
@@ -191,6 +191,17 @@ export type RHFCountrySelectProps<
   ChipProps?: MuiChipProps;
 } & AutoCompleteProps<Multiple, DisableClearable>;
 
+/**
+ * MUI `Autocomplete` preloaded with a full country list (flags, names, dial
+ * codes), wired to a React Hook Form field via `control`.
+ *
+ * Supports `preferredCountries` pinned to the top, and single or multiple
+ * selection through the `multiple` prop.
+ *
+ * Docs: [RHFCountrySelect](https://rhf-mui-components.vercel.app/v3/components/mui/RHFCountrySelect)
+ *
+ * API: [RHFCountrySelectProps](https://rhf-mui-components.vercel.app/v3/components/mui/RHFCountrySelect#api)
+ */
 const RHFCountrySelect = <
   T extends FieldValues,
   Multiple extends boolean = false,

--- a/packages/rhf-mui-components/src/mui/file-uploader/index.tsx
+++ b/packages/rhf-mui-components/src/mui/file-uploader/index.tsx
@@ -175,6 +175,18 @@ export type RHFFileUploaderProps<
   fullWidth?: boolean;
 };
 
+/**
+ * File input wired to a React Hook Form field via `control`, validating
+ * `accept`, `maxSize` and `maxFiles`, with rejected files reported via
+ * `onUploadError`.
+ *
+ * The accepted-file type in `onValueChange` is generic on `multiple`: `File[]`
+ * when `true`, a single `File` otherwise.
+ *
+ * Docs: [RHFFileUploader](https://rhf-mui-components.vercel.app/v3/components/mui/RHFFileUploader)
+ *
+ * API: [RHFFileUploaderProps](https://rhf-mui-components.vercel.app/v3/components/mui/RHFFileUploader#api)
+ */
 const RHFFileUploader = <
   T extends FieldValues,
   Multiple extends boolean = false,

--- a/packages/rhf-mui-components/src/mui/multi-autocomplete-object/index.tsx
+++ b/packages/rhf-mui-components/src/mui/multi-autocomplete-object/index.tsx
@@ -184,6 +184,17 @@ export type RHFMultiAutocompleteObjectProps<
   circularProgressProps?: CircularProgressProps;
 } & MultiAutoCompleteProps<Option, DisableClearable>;
 
+/**
+ * Always-multiple MUI `Autocomplete` wired to a React Hook Form array field
+ * via `control`, storing the full selected option objects with a checkbox
+ * per option.
+ *
+ * Includes a built-in "**Select All**" option, hideable via `hideSelectAllOption`.
+ *
+ * Docs: [RHFMultiAutocompleteObject](https://rhf-mui-components.vercel.app/v3/components/mui/RHFMultiAutocompleteObject)
+ *
+ * API: [RHFMultiAutocompleteObjectProps](https://rhf-mui-components.vercel.app/v3/components/mui/RHFMultiAutocompleteObject#api)
+ */
 const RHFMultiAutocompleteObject = <
   T extends FieldValues,
   Option extends KeyValueOption = KeyValueOption,

--- a/packages/rhf-mui-components/src/mui/multi-autocomplete/index.tsx
+++ b/packages/rhf-mui-components/src/mui/multi-autocomplete/index.tsx
@@ -187,6 +187,16 @@ export type RHFMultiAutocompleteProps<
   circularProgressProps?: CircularProgressProps;
 } & MultiAutoCompleteProps<Option, DisableClearable>;
 
+/**
+ * Always-multiple MUI `Autocomplete` wired to a React Hook Form array field
+ * via `control`, with a checkbox per option in the dropdown.
+ *
+ * Includes a built-in "**Select All**" option, hideable via `hideSelectAllOption`.
+ *
+ * Docs: [RHFMultiAutocomplete](https://rhf-mui-components.vercel.app/v3/components/mui/RHFMultiAutocomplete)
+ *
+ * API: [RHFMultiAutocompleteProps](https://rhf-mui-components.vercel.app/v3/components/mui/RHFMultiAutocomplete#api)
+ */
 const RHFMultiAutocomplete = <
   T extends FieldValues,
   Option extends StrObjOption = StrObjOption,

--- a/packages/rhf-mui-components/src/mui/native-select/index.tsx
+++ b/packages/rhf-mui-components/src/mui/native-select/index.tsx
@@ -116,6 +116,17 @@ export type RHFNativeSelectProps<
   formHelperTextProps?: Omit<FormHelperTextProps, 'id'>;
 } & InputNativeSelectProps;
 
+/**
+ * Controlled MUI `NativeSelect` (native HTML `<select>`) wired to a React
+ * Hook Form field via `control`.
+ *
+ * Accepts string/number or object options via
+ * `labelKey`/`valueKey`; best for small-to-moderate option lists.
+ *
+ * Docs: [RHFNativeSelect](https://rhf-mui-components.vercel.app/v3/components/mui/RHFNativeSelect)
+ *
+ * API: [RHFNativeSelectProps](https://rhf-mui-components.vercel.app/v3/components/mui/RHFNativeSelect#api)
+ */
 const RHFNativeSelect = <
   T extends FieldValues,
   Option extends StrNumObjOption = StrNumObjOption,

--- a/packages/rhf-mui-components/src/mui/number-input/index.tsx
+++ b/packages/rhf-mui-components/src/mui/number-input/index.tsx
@@ -83,6 +83,16 @@ export type RHFNumberInputProps<T extends FieldValues> = {
   formHelperTextProps?: Omit<FormHelperTextProps, 'id'>;
 } & TextFieldInputProps;
 
+/**
+ * Controlled MUI `TextField` (`type="number"`) wired to a React Hook Form
+ * field via `control`, storing the value as a `number` (or `null` when empty).
+ *
+ * Optional `showMarkers` reveals the native increment/decrement spinners.
+ *
+ * Docs: [RHFNumberInput](https://rhf-mui-components.vercel.app/v3/components/mui/RHFNumberInput)
+ *
+ * API: [RHFNumberInputProps](https://rhf-mui-components.vercel.app/v3/components/mui/RHFNumberInput#api)
+ */
 const RHFNumberInput = <T extends FieldValues>({
   fieldName,
   control,

--- a/packages/rhf-mui-components/src/mui/password-input/index.tsx
+++ b/packages/rhf-mui-components/src/mui/password-input/index.tsx
@@ -125,6 +125,17 @@ export type RHFPasswordInputProps<T extends FieldValues> = {
   formHelperTextProps?: Omit<FormHelperTextProps, 'id'>;
 } & InputPasswordProps;
 
+/**
+ * Controlled MUI `TextField` wired to a React Hook Form field via `control`,
+ * with a built-in show/hide password toggle.
+ *
+ * `readOnly` keeps the field focusable and the toggle usable (unlike `disabled`,
+ * which makes the whole field inert).
+ *
+ * Docs: [RHFPasswordInput](https://rhf-mui-components.vercel.app/v3/components/mui/RHFPasswordInput)
+ *
+ * API: [RHFPasswordInputProps](https://rhf-mui-components.vercel.app/v3/components/mui/RHFPasswordInput#api)
+ */
 const RHFPasswordInput = <T extends FieldValues>({
   fieldName,
   control,

--- a/packages/rhf-mui-components/src/mui/radio-group/index.tsx
+++ b/packages/rhf-mui-components/src/mui/radio-group/index.tsx
@@ -129,6 +129,16 @@ export type RHFRadioGroupProps<
   formHelperTextProps?: Omit<FormHelperTextProps, 'id'>;
 } & RadioGroupInputProps;
 
+/**
+ * MUI `RadioGroup` wired to a React Hook Form field via `control`, one
+ * `Radio` per `options` entry.
+ *
+ * Accepts string/number or object options via `labelKey`/`valueKey`.
+ *
+ * Docs: [RHFRadioGroup](https://rhf-mui-components.vercel.app/v3/components/mui/RHFRadioGroup)
+ *
+ * API: [RHFRadioGroupProps](https://rhf-mui-components.vercel.app/v3/components/mui/RHFRadioGroup#api)
+ */
 const RHFRadioGroup = <
   T extends FieldValues,
   Option extends StrNumObjOption = StrNumObjOption,

--- a/packages/rhf-mui-components/src/mui/rating/index.tsx
+++ b/packages/rhf-mui-components/src/mui/rating/index.tsx
@@ -86,6 +86,16 @@ export type RHFRatingProps<T extends FieldValues> = {
   formHelperTextProps?: Omit<FormHelperTextProps, 'id'>;
 } & InputRatingProps;
 
+/**
+ * Controlled MUI `Rating` wired to a React Hook Form field via `control`,
+ * storing the value as a `number` (or `null` when cleared).
+ *
+ * Supports MUI's `precision` for half-star ratings and custom icons.
+ *
+ * Docs: [RHFRating](https://rhf-mui-components.vercel.app/v3/components/mui/RHFRating)
+ *
+ * API: [RHFRatingProps](https://rhf-mui-components.vercel.app/v3/components/mui/RHFRating#api)
+ */
 const RHFRating = <T extends FieldValues>({
   fieldName,
   control,

--- a/packages/rhf-mui-components/src/mui/select/index.tsx
+++ b/packages/rhf-mui-components/src/mui/select/index.tsx
@@ -161,6 +161,17 @@ export type RHFSelectProps<
   placeholder?: string;
 } & SelectProps;
 
+/**
+ * Controlled MUI `Select` wired to a React Hook Form field via `control`.
+ *
+ * Supports single or multiple selection through the `multiple` prop, with
+ * `onValueChange`'s value type generic on it, plus an optional `showDefaultOption`
+ * placeholder item.
+ *
+ * Docs: [RHFSelect](https://rhf-mui-components.vercel.app/v3/components/mui/RHFSelect)
+ *
+ * API: [RHFSelectProps](https://rhf-mui-components.vercel.app/v3/components/mui/RHFSelect#api)
+ */
 const RHFSelect = <
   T extends FieldValues,
   Option extends StrNumObjOption = StrNumObjOption,

--- a/packages/rhf-mui-components/src/mui/slider/index.tsx
+++ b/packages/rhf-mui-components/src/mui/slider/index.tsx
@@ -97,6 +97,17 @@ export type RHFSliderProps<
   formHelperTextProps?: Omit<FormHelperTextProps, 'id'>;
 } & SliderInputProps;
 
+/**
+ * Controlled MUI `Slider` wired to a React Hook Form field via `control`,
+ * supporting both single-thumb and range sliders.
+ *
+ * `onValueChange`'s `value` type is inferred from the field's declared type
+ * in your form schema (`number` vs `number[]`).
+ *
+ * Docs: [RHFSlider](https://rhf-mui-components.vercel.app/v3/components/mui/RHFSlider)
+ *
+ * API: [RHFSliderProps](https://rhf-mui-components.vercel.app/v3/components/mui/RHFSlider#api)
+ */
 const RHFSlider = <
   T extends FieldValues,
   TName extends Path<T> = Path<T>

--- a/packages/rhf-mui-components/src/mui/switch/index.tsx
+++ b/packages/rhf-mui-components/src/mui/switch/index.tsx
@@ -73,6 +73,13 @@ export type RHFSwitchProps<T extends FieldValues> = {
   formHelperTextProps?: Omit<FormHelperTextProps, 'id'>;
 } & Omit<SwitchProps, 'name'>;
 
+/**
+ * Controlled MUI `Switch` wired to a React Hook Form boolean field via `control`.
+ *
+ * Docs: [RHFSwitch](https://rhf-mui-components.vercel.app/v3/components/mui/RHFSwitch)
+ *
+ * API: [RHFSwitchProps](https://rhf-mui-components.vercel.app/v3/components/mui/RHFSwitch#api)
+ */
 const RHFSwitch = <T extends FieldValues>({
   fieldName,
   control,

--- a/packages/rhf-mui-components/src/mui/tags-input/index.tsx
+++ b/packages/rhf-mui-components/src/mui/tags-input/index.tsx
@@ -118,6 +118,16 @@ export type RHFTagsInputProps<T extends FieldValues> = {
   getLimitTagsText?: (moreTags: number) => ReactNode;
 } & TextFieldInputProps;
 
+/**
+ * Free-form MUI `TextField` wired to a React Hook Form `string[]` field via
+ * `control`, letting users type and add arbitrary tags as chips.
+ *
+ * Collapses overflow tags past `limitTags`, customizable via `getLimitTagsText`.
+ *
+ * Docs: [RHFTagsInput](https://rhf-mui-components.vercel.app/v3/components/mui/RHFTagsInput)
+ *
+ * API: [RHFTagsInputProps](https://rhf-mui-components.vercel.app/v3/components/mui/RHFTagsInput#api)
+ */
 const RHFTagsInput = <T extends FieldValues>({
   fieldName,
   control,

--- a/packages/rhf-mui-components/src/mui/textfield/index.tsx
+++ b/packages/rhf-mui-components/src/mui/textfield/index.tsx
@@ -73,6 +73,13 @@ export type RHFTextFieldProps<T extends FieldValues> = {
   formHelperTextProps?: Omit<FormHelperTextProps, 'id'>;
 } & TextFieldProps;
 
+/**
+ * Controlled MUI `TextField` wired to a React Hook Form field via `control`.
+ *
+ * Docs: [RHFTextField](https://rhf-mui-components.vercel.app/v3/components/mui/RHFTextField)
+ *
+ * API: [RHFTextFieldProps](https://rhf-mui-components.vercel.app/v3/components/mui/RHFTextField#api)
+ */
 const RHFTextField = <T extends FieldValues>({
   fieldName,
   control,


### PR DESCRIPTION
## **User description**
### ✨ Enhancements
- Added component-level JSDoc summaries (with links to docs and API reference) to every `RHF*` component across the `mui`, `mui-pickers` and `misc` modules.


___

## **CodeAnt-AI Description**
Document all React Hook Form MUI components with linked usage and API references

### What Changed
- Added component-level documentation for inputs, selectors, pickers, uploaders, editors, and other form controls
- Documented supported value formats, selection modes, validation behavior, customization options, and notable usage guidance
- Added direct links to the documentation and API reference for each component
- Documented the default rich-text editor configuration and clarified the select-all constant
- Released version 3.7.3 across the package, demo, and documentation apps

### Impact
`✅ Faster access to component usage guidance`
`✅ Clearer form value and validation expectations`
`✅ Direct links to API references`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
